### PR TITLE
BUGFIX Force the migrated comment to be inserted into the database.

### DIFF
--- a/code/dataobjects/Comment.php
+++ b/code/dataobjects/Comment.php
@@ -47,7 +47,8 @@ class Comment extends DataObject {
 			if($comments) {
 				while($pageComment = $comments->nextRecord()) {
 					// create a new comment from the older page comment
-					$comment = new Comment($pageComment);
+					$comment = new Comment();
+					$comment->update($pageComment);
 					
 					// set the variables which have changed
 					$comment->BaseClass = 'SiteTree';


### PR DESCRIPTION
The current migration script just inserts a bunch of empty rows.

I've done it this way rather than forcing an insert so that Created isn't changed.
