### PR TITLE
Limit the number of comments in the rss feed

### DIFF
--- a/code/Commenting.php
+++ b/code/Commenting.php
@@ -29,6 +29,7 @@ class Commenting {
 		'show_comments_when_disabled' => false, // when comments are disabled should we show older comments (if available)
 		'order_comments_by' => "\"Created\" DESC",
 		'comments_per_page' => 10,
+		'rss_comments_per_page' => 10,
 		'comments_holder_id' => "comments-holder", // id for the comments holder
 		'comment_permalink_prefix' => "comment-", // id prefix for each comment. If needed make this different
 		'require_moderation' => false

--- a/code/controllers/CommentingController.php
+++ b/code/controllers/CommentingController.php
@@ -102,6 +102,9 @@ class CommentingController extends Controller {
 			$comments = Comment::get();
 		}
 
+		$rssItemNum = Commenting::get_config_value($class ? $class : 'SiteTree', 'rss_comments_per_page');
+		if($rssItemNum) $comments = $comments->limit($rssItemNum); 
+
 		$title = _t('CommentingController.RSSTITLE', "Comments RSS Feed");
 
 		$feed = new RSSFeed($comments, $link, $title, $link, 'Title', 'Comment', 'AuthorName');

--- a/docs/en/Configuration.md
+++ b/docs/en/Configuration.md
@@ -11,6 +11,7 @@ The module provides a number of built in configuration settings below are the de
 		'show_comments_when_disabled' => false,
 		'order_comments_by' => "\"Created\" DESC",
 		'comments_per_page' => 10,
+		'rss_comments_per_page' => 10,
 		'comments_holder_id' => "comments-holder", 
 		'comment_permalink_prefix' => "comment-",
 		'require_moderation' => false


### PR DESCRIPTION
... instead of returning all of them which can cause a performance issue when the number of comment is high.
