### PR TITLE
BUG: Fixing moderation on the comments module

### DIFF
--- a/code/controllers/CommentingController.php
+++ b/code/controllers/CommentingController.php
@@ -357,6 +357,12 @@ class CommentingController extends Controller {
 
 		// is moderation turned on
 		$moderated = Commenting::get_config_value($class, 'require_moderation');
+
+		// we want to show a notification if comments are moderated
+		if ($moderated) {
+			Session::set('CommentsModerated', 1);
+		}
+
 		
 		$comment = new Comment();
 		$form->saveInto($comment);

--- a/templates/CommentsInterface.ss
+++ b/templates/CommentsInterface.ss
@@ -4,6 +4,9 @@
 		
 		<% if AddCommentForm %>
 			<% if CanPost %>
+				<% if ModeratedSubmitted %>
+					<p id="PageCommentInterface_Form_PostCommentForm_error" class="message good"><% _t('AWAITINGMODERATION', 'Your comment has been submitted and is now awaiting moderation.') %></p>
+				<% end_if %>
 				$AddCommentForm
 			<% else %>
 				<p><% _t('COMMENTLOGINERROR', 'You cannot post comments until you have logged in') %><% if PostingRequiresPermission %>,<% _t('COMMENTPERMISSIONERROR', 'and that you have an appropriate permission level') %><% end_if %>. 


### PR DESCRIPTION
As part of some upgrading work I have done I have added the moderation back to the Comments module for 3.0.1
