### PR TITLE
BUGFIX: Added missing onAfterPostComment hook

### DIFF
--- a/code/controllers/CommentingController.php
+++ b/code/controllers/CommentingController.php
@@ -369,6 +369,9 @@ class CommentingController extends Controller {
 
 		$comment->Moderated = ($moderated) ? false : true;
 		$comment->write();
+
+		// extend hook to allow extensions. Also see onBeforePostComment
+		$this->extend('onAfterPostComment', $comment);	
 		
 		// clear the users comment since it passed validation
 		Cookie::set('CommentsForm_Comment', false);


### PR DESCRIPTION
Additional notification hook after when a comment has been posted.  See https://github.com/silverstripe/silverstripe-comments/issues/37#issuecomment-10794115
