### PR TITLE
option require moderation for non-members only

### DIFF
--- a/code/Commenting.php
+++ b/code/Commenting.php
@@ -36,6 +36,7 @@ class Commenting {
 		'comments_holder_id' => "comments-holder", // id for the comments holder
 		'comment_permalink_prefix' => "comment-", // id prefix for each comment. If needed make this different
 		'require_moderation' => false,
+		'require_moderation_nonmembers' => false, // requires moderation for comments posted by non-members. 'require_moderation' overrides this if set.
 		'html_allowed' => false, // allow for sanitized HTML in comments
 		'html_allowed_elements' => array('a', 'img', 'i', 'b'),
 		'use_preview' => false, // preview formatted comment (when allowing HTML). Requires include_js=true
@@ -80,7 +81,7 @@ class Commenting {
 	 * @return bool
 	 */
 	public static function has_commenting($class) {
-		return (isset(self::$enabled_classes[$class]));
+	  return (isset(self::$enabled_classes[$class]));
 	}
 
 	/**

--- a/code/extensions/CommentsExtension.php
+++ b/code/extensions/CommentsExtension.php
@@ -57,14 +57,14 @@ class CommentsExtension extends DataExtension {
 
 		// Filter content for unauthorised users
 		if (!($member = Member::currentUser()) || !Permission::checkMember($member, 'CMS_ACCESS_CommentAdmin')) {
-			
-			// Filter unmoderated comments for non-administrators if moderation is enabled
-			if (Commenting::get_config_value($this->ownerBaseClass, 'require_moderation')) {
-				$list = $list->filter('Moderated', 1);
-			} else {
-				// Filter spam comments for non-administrators if auto-moderted
-				$list = $list->filter('IsSpam', 0);
-			}
+		  
+		  // Filter unmoderated comments for non-administrators if moderation is enabled
+		  if (Commenting::get_config_value($this->ownerBaseClass, 'require_moderation') || Commenting::get_config_value($this->ownerBaseClass, 'require_moderation_nonmembers')) {
+		    $list = $list->filter('Moderated', 1);
+		  } else {
+		    // Filter spam comments for non-administrators if auto-moderted
+		    $list = $list->filter('IsSpam', 0);
+		  }
 		}
 
 		$list = new PaginatedList($list);
@@ -106,7 +106,7 @@ class CommentsExtension extends DataExtension {
 		// on a {@link DataObject} then it is enabled, however {@link SiteTree} objects can
 		// trigger comments on / off via ProvideComments
 		$enabled = (!$this->attachedToSiteTree() || $this->owner->ProvideComments) ? true : false;
-		
+
 		// do not include the comments on pages which don't have id's such as security pages
 		if($this->owner->ID < 0) return false;
 		


### PR DESCRIPTION
added config option 'require_moderation_nonmembers' = when set, only comments posted by non-members will require moderation

comment bodies now populate with previous value after validation errors (i.e. spam protection)
