### PR TITLE
Prevent errors when comments' parent pages have been removed

### DIFF
--- a/code/dataobjects/Comment.php
+++ b/code/dataobjects/Comment.php
@@ -100,7 +100,9 @@ class Comment extends DataObject {
 	 * @return string link to this comment.
 	 */
 	public function Link($action = "") {
-		return $this->getParent()->Link($action) . '#' . $this->Permalink();
+	  if($parent = $this->getParent()){
+		return $parent->Link($action) . '#' . $this->Permalink();
+	  }
 	}
 	
 	/**
@@ -150,9 +152,9 @@ class Comment extends DataObject {
 	 * @return string
 	 */
 	public function getParentTitle() {
-		$parent = $this->getParent();
-
+	  if($parent = $this->getParent()){
 		return ($parent && $parent->Title) ? $parent->Title : $parent->ClassName . " #" . $parent->ID;
+	  }
 	}
 
 	/**


### PR DESCRIPTION
A bit of an edge case, but may help others too
