### PR TITLE
Ensure that comment module does not overwrite users config with the stan...

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -26,6 +26,6 @@
  * consult the Commenting class.
  */
 
-if(class_exists('SiteTree')) {
+if(class_exists('SiteTree') && !Commenting::has_commenting('SiteTree')) {
 	Commenting::add('SiteTree');
 }


### PR DESCRIPTION
...dard config
In my case I couldn't configure commenting, since any configuration was overwritten by the comments/_config.php setting. I would rather remove the enabling of comments altogether in the _config.php file, but this way it doesn't break working installations.
