### PR TITLE
FIX: Ensure that comments edited using AJAX are themselves AJAX editable

### DIFF
--- a/javascript/CommentsInterface.js
+++ b/javascript/CommentsInterface.js
@@ -111,7 +111,7 @@
 		 * Clicking one of the metalinks performs the operation via ajax
 		 * this inclues the spam and approve links
 		 */
-		$(".action-links a", commentsList).on('click', function(e) {
+		commentsList.on('click', '.action-links a', function(e) {
 			var link = $(this);
 			var comment = link.parents('.comment:first');
 			


### PR DESCRIPTION
Fix for ISSUE82, where comments that have been marked as spam or approved are themselves still editable after being altered by clicking on the relevant spam/approval buttons
