### PR TITLE
Setting third-party module dependency to latest known version that works

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 	}],
 	"require": {
 		"silverstripe/framework": "~3.1",
-		"colymba/gridfield-bulk-editing-tools": "dev-master"
+		"colymba/gridfield-bulk-editing-tools": "2.0.2"
 	},
 	"suggest": {
 		"ezyang/htmlpurifier": "4.*"


### PR DESCRIPTION
Switch to the latest known stable version to work. 2.1.0 (current latest on gridfield_bulk_editing_tools) is broken, with a YAML error: https://github.com/colymba/GridFieldBulkEditingTools/commit/1ceee593609c421f1507438304775774ba166251#commitcomment-7778609
