### PR TITLE
Update composer to point to now fixed 2.1 branch of bulk editing tools

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,14 @@
 	}],
 	"require": {
 		"silverstripe/framework": "~3.1",
-		"colymba/gridfield-bulk-editing-tools": "2.0.2"
+		"colymba/gridfield-bulk-editing-tools": "~2.1"
 	},
 	"suggest": {
 		"ezyang/htmlpurifier": "4.*"
+	},
+	"extra": {
+		"branch-alias": {
+			"dev-master": "1.2.x-dev"
+		}
 	}
 }


### PR DESCRIPTION
Originally this was fixed to a specific stable version due to the issue at https://github.com/colymba/GridFieldBulkEditingTools/commit/1ceee593609c421f1507438304775774ba166251#commitcomment-7778609

Fixes #87 

Also alias dev-master as 1.2
