### PR TITLE
UPDATE: explicitly provide permissions for comment administration

### DIFF
--- a/code/CommentAdmin.php
+++ b/code/CommentAdmin.php
@@ -5,7 +5,7 @@
  *
  * @package comments
  */
-class CommentAdmin extends LeftAndMain {
+class CommentAdmin extends LeftAndMain implements PermissionProvider {
 
 	private static $url_segment = 'comments';
 
@@ -23,6 +23,15 @@ class CommentAdmin extends LeftAndMain {
 		'EditForm',
 		'unmoderated'
 	);
+
+	public function providePermissions() {
+		return array(
+			"CMS_ACCESS_CommentAdmin" => array(
+				'name' => _t('CommentAdmin.ADMIN_PERMISSION', "Access to 'Comments' section"),
+				'category' => _t('Permission.CMS_ACCESS_CATEGORY', 'CMS Access')
+			)
+		);
+	}
 
 	/**
 	 * @return Form

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -17,6 +17,7 @@ en:
     Moderated: Moderated
     NeedsModeration: 'Needs Moderation'
     MENUTITLE: Comments
+    ADMIN_PERMISSION: "Access to 'Comments' section"
   CommentInterface:
     POST: Post
     YOURNAME: 'Your name'


### PR DESCRIPTION
Currently only administrators can access the comments section. Content editors and other groups should be able to access this section as well.
