### PR TITLE
Provide better temporary location for HTMLPurifier cache files

### DIFF
--- a/code/dataobjects/Comment.php
+++ b/code/dataobjects/Comment.php
@@ -398,6 +398,7 @@ class Comment extends DataObject {
 		$config->set('AutoFormat.AutoParagraph', true);
 		$config->set('AutoFormat.Linkify', true);
 		$config->set('URI.DisableExternalResources', true);
+		$config->set('Cache.SerializerPath', getTempFolder());
 		return new HTMLPurifier($config);
 	}
 


### PR DESCRIPTION
Without this setting, this feature will write inside the vendor folder, which is not always desirable.