### PR TITLE
NEW Only add comments to SiteTree objects if needed

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -26,6 +26,6 @@
  * consult the Commenting class.
  */
 
-if(class_exists('SiteTree') && !Commenting::has_commenting('SiteTree')) {
+if(Config::inst()->get('Commenting', 'sitetree_comments') && class_exists('SiteTree') && !Commenting::has_commenting('SiteTree')) {
 	Commenting::add('SiteTree');
 }

--- a/code/Commenting.php
+++ b/code/Commenting.php
@@ -13,12 +13,18 @@
  */
 
 class Commenting {
-	
+
 	/**
 	 * @var array map of enabled {@link DataObject} and related configuration
 	 */
 	private static $enabled_classes = array();
-	
+
+	/**
+	 * @config
+	 * @var bool Whether to enable commenting on SiteTree objects by default
+	 */
+	private static $sitetree_comments = true;
+
 	/**
 	 * @var array default configuration values
 	 */


### PR DESCRIPTION
Commenting doesn't need to be on SiteTree by default and should be configurable at least.