### PR TITLE
Change label from 'Parent' to 'Blog Post'

### DIFF
--- a/code/dataobjects/Comment.php
+++ b/code/dataobjects/Comment.php
@@ -52,7 +52,7 @@ class Comment extends DataObject {
 		'Email' => 'Email',
 		'Comment' => 'Comment',
 		'Created' => 'Date Posted',
-		'ParentTitle' => 'Parent',
+		'ParentTitle' => 'Blog Post',
 		'IsSpam' => 'Is Spam'
 	);
 


### PR DESCRIPTION
Renamed the title 'Parent' to a more user-friendly 'Blog Post' title