### PR TITLE
Better redirection on posting of comment

### DIFF
--- a/templates/CommentsInterface.ss
+++ b/templates/CommentsInterface.ss
@@ -1,11 +1,11 @@
-<% if CommentsEnabled %>
+<% if $CommentsEnabled %>
 	<div id="$CommentHolderID" class="comments-holder-container">
 		<h4><% _t('CommentsInterface_ss.POSTCOM','Post your comment') %></h4>
 		
-		<% if AddCommentForm %>
-			<% if CanPost %>
-				<% if ModeratedSubmitted %>
-					<p id="$CommentHolderID_PostCommentForm_error" class="message good"><% _t('CommentsInterface_ss.AWAITINGMODERATION', 'Your comment has been submitted and is now awaiting moderation.') %></p>
+		<% if $AddCommentForm %>
+			<% if $CanPost %>
+				<% if $ModeratedSubmitted %>
+					<p id="{$CommentHolderID}_PostCommentForm_error" class="message good"><% _t('CommentsInterface_ss.AWAITINGMODERATION', 'Your comment has been submitted and is now awaiting moderation.') %></p>
 				<% end_if %>
 				$AddCommentForm
 			<% else %>
@@ -20,25 +20,25 @@
 		<h4><% _t('CommentsInterface_ss.COMMENTS','Comments') %></h4>
 	
 		<div class="comments-holder">
-			<% if Comments %>
+			<% if $Comments %>
 				<ul class="comments-list">
-					<% loop Comments %>
+					<% loop $Comments %>
 						<li class="comment $EvenOdd<% if FirstLast %> $FirstLast <% end_if %> $SpamClass">
 							<% include CommentsInterface_singlecomment %>
 						</li>
 					<% end_loop %>
 				</ul>
 			
-				<% if Comments.MoreThanOnePage %>
+				<% if $Comments.MoreThanOnePage %>
 					<div class="comments-pagination">
 						<p>
-							<% if Comments.PrevLink %>
+							<% if $Comments.PrevLink %>
 								<a href="$Comments.PrevLink" class="previous">&laquo; <% _t('CommentsInterface_ss.PREV','previous') %></a>
 							<% end_if %>
 					
-							<% if Comments.Pages %>
-								<% loop Comments.Pages %>
-									<% if CurrentBool %>
+							<% if $Comments.Pages %>
+								<% loop $Comments.Pages %>
+									<% if $CurrentBool %>
 										<strong>$PageNum</strong>
 									<% else %>
 										<a href="$Link">$PageNum</a>
@@ -46,7 +46,7 @@
 								<% end_loop %>
 							<% end_if %>
 	
-							<% if Comments.NextLink %>
+							<% if $Comments.NextLink %>
 								<a href="$Comments.NextLink" class="next"><% _t('CommentsInterface_ss.NEXT','next') %> &raquo;</a>
 							<% end_if %>
 						</p>
@@ -58,7 +58,7 @@
 
 		</div>
 		
-		<% if DeleteAllLink %>
+		<% if $DeleteAllLink %>
 			<p class="delete-comments">
 				<a href="$DeleteAllLink"><% _t('CommentsInterface_ss.PageCommentInterface.DELETEALLCOMMENTS','Delete all comments on this page') %></a>
 			</p>

--- a/templates/CommentsInterface_singlecomment.ss
+++ b/templates/CommentsInterface_singlecomment.ss
@@ -1,4 +1,4 @@
-<div class="comment" id="<% if isPreview %>comment-preview<% else %>$Permalink<% end_if %>">
+<div class="comment" id="<% if $isPreview %>comment-preview<% else %>$Permalink<% end_if %>">
 <% if $Gravatar %><img class="gravatar" src="$Gravatar" alt="Gravatar for $Name" title="Gravatar for $Name" /><% end_if %>
 	$EscapedComment
 </div>
@@ -14,16 +14,16 @@
 
 	<% if $ApproveLink || $SpamLink || $HamLink || $DeleteLink %>
 		<ul class="action-links">
-			<% if ApproveLink %>
+			<% if $ApproveLink %>
 				<li><a href="$ApproveLink.ATT" class="approve"><% _t('CommentsInterface_singlecomment_ss.APPROVE', 'approve this comment') %></a></li>
 			<% end_if %>
-			<% if SpamLink %>
+			<% if $SpamLink %>
 				<li><a href="$SpamLink.ATT" class="spam"><% _t('CommentsInterface_singlecomment_ss.ISSPAM','this comment is spam') %></a></li>
 			<% end_if %>
-			<% if HamLink %>
+			<% if $HamLink %>
 				<li><a href="$HamLink.ATT" class="ham"><% _t('CommentsInterface_singlecomment_ss.ISNTSPAM','this comment is not spam') %></a></li>
 			<% end_if %>
-			<% if DeleteLink %>
+			<% if $DeleteLink %>
 				<li class="last"><a href="$DeleteLink.ATT" class="delete"><% _t('CommentsInterface_singlecomment_ss.REMCOM','remove this comment') %></a></li>
 			<% end_if %>
 		</ul>


### PR DESCRIPTION
If a user posts a spam comment, ensure that (even if it's saved) that the user is redirected to the form which they posted to.

Also cleanup some old code in the templates.

Also clean up some garbage code and misleading variable names, indentation, better security handling.