### PR TITLE
API Restore ability to do frontend-moderation

### DIFF
--- a/docs/en/Configuration.md
+++ b/docs/en/Configuration.md
@@ -24,7 +24,7 @@ SiteTree:
   extensions:
 	- CommentsExtension
   comments:
-	enabled: true # Enables commenting to be disabled for a specific class (or subclass of a parent with commenting enabled)
+    enabled: true # Enables commenting to be disabled for a specific class (or subclass of a parent with commenting enabled)
     enabled_cms: false # The 'enabled' option will be set via the CMS instead of config
     require_login: false # boolean, whether a user needs to login
     require_login_cms: false # The 'require_login' option will be set via the CMS instead of config
@@ -40,8 +40,10 @@ SiteTree:
     comments_holder_id: 'comments-holder' # id for the comments holder
     comment_permalink_prefix: 'comment-' # id prefix for each comment. If needed make this different
     require_moderation: false
-	require_moderation_nonmembers: false # requires moderation for comments posted by non-members. 'require_moderation' overrides this if set.
-	require_moderation_cms: false # If true, ignore above values and configure moderation requirements via the CMS only
+    require_moderation_nonmembers: false # requires moderation for comments posted by non-members. 'require_moderation' overrides this if set.
+    require_moderation_cms: false # If true, ignore above values and configure moderation requirements via the CMS only
+    frontend_moderation: false # Display unmoderated comments in the frontend, if the user can moderate them.
+    frontend_spam: false # Display spam comments in the frontend, if the user can moderate them.
     html_allowed: false # allow for sanitized HTML in comments
     html_allowed_elements:
       - a

--- a/tests/CommentsTest.php
+++ b/tests/CommentsTest.php
@@ -57,6 +57,41 @@ class CommentsTest extends FunctionalTest {
 		
 		Config::inst()->update('CommentableItem', 'comments', array('require_moderation_nonmembers' => false));
 		$this->assertEquals(2, $item->Comments()->Count());
+
+		// With unmoderated comments set to display in frontend
+		Config::inst()->update('CommentableItem', 'comments', array(
+			'require_moderation' => true,
+			'frontend_moderation' => true
+		));
+		$this->assertEquals(1, $item->Comments()->Count());
+
+		$this->logInWithPermission('ADMIN');
+		$this->assertEquals(2, $item->Comments()->Count());
+
+		// With spam comments set to display in frontend
+		Config::inst()->update('CommentableItem', 'comments', array(
+			'require_moderation' => true,
+			'frontend_moderation' => false,
+			'frontend_spam' => true,
+		));
+		if($member = Member::currentUser()) $member->logOut();
+		$this->assertEquals(1, $item->Comments()->Count());
+
+		$this->logInWithPermission('ADMIN');
+		$this->assertEquals(2, $item->Comments()->Count());
+
+
+		// With spam and unmoderated comments set to display in frontend
+		Config::inst()->update('CommentableItem', 'comments', array(
+			'require_moderation' => true,
+			'frontend_moderation' => true,
+			'frontend_spam' => true,
+		));
+		if($member = Member::currentUser()) $member->logOut();
+		$this->assertEquals(1, $item->Comments()->Count());
+
+		$this->logInWithPermission('ADMIN');
+		$this->assertEquals(4, $item->Comments()->Count());
 	}
 
 	/**


### PR DESCRIPTION
This feature is disabled by default, but can be turned on either for spam, unmoderated comments, or both.