### PR TITLE
BUG Correct formatting of ParentTitle

### DIFF
--- a/code/admin/CommentsGridFieldConfig.php
+++ b/code/admin/CommentsGridFieldConfig.php
@@ -14,8 +14,8 @@ class CommentsGridFieldConfig extends GridFieldConfig_RecordEditor {
 			'ParentTitle' => function($value, &$item) {
 				return sprintf(
 					'<a href="%s" class="cms-panel-link external-link action" target="_blank">%s</a>',
-					Convert::raw2xml($item->Link()),
-					Convert::raw2xml($value)
+					Convert::raw2att($item->Link()),
+					$item->obj('ParentTitle')->forTemplate()
 				);
 			}
 		));


### PR DESCRIPTION
It seems the issue is that GridFieldDataColumns::castValue doesn't bother to check the casting helpers on the source object, so do it in the custom column formatter instead.