### PR TITLE
BUG Fix each gridfield having triple gridstate components

### DIFF
--- a/code/admin/CommentAdmin.php
+++ b/code/admin/CommentAdmin.php
@@ -46,15 +46,13 @@ class CommentAdmin extends LeftAndMain implements PermissionProvider {
 			return Security::permissionFailure($this);
 		}
 
-		$commentsConfig = CommentsGridFieldConfig::create();
-
 		$newComments = Comment::get()->filter('Moderated', 0);
 
 		$newGrid = new CommentsGridField(
 			'NewComments',
 			_t('CommentsAdmin.NewComments', 'New'),
 			$newComments,
-			$commentsConfig
+			CommentsGridFieldConfig::create()
 		);
 
 		$approvedComments = Comment::get()->filter('Moderated', 1)->filter('IsSpam', 0);
@@ -63,7 +61,7 @@ class CommentAdmin extends LeftAndMain implements PermissionProvider {
 			'ApprovedComments',
 			_t('CommentsAdmin.ApprovedComments', 'Approved'),
 			$approvedComments,
-			$commentsConfig
+			CommentsGridFieldConfig::create()
 		);
 
 		$spamComments = Comment::get()->filter('Moderated', 1)->filter('IsSpam', 1);
@@ -72,7 +70,7 @@ class CommentAdmin extends LeftAndMain implements PermissionProvider {
 			'SpamComments',
 			_t('CommentsAdmin.SpamComments', 'Spam'),
 			$spamComments,
-			$commentsConfig
+			CommentsGridFieldConfig::create()
 		);
 
 		$newCount = '(' . count($newComments) . ')';

--- a/code/extensions/CommentsExtension.php
+++ b/code/extensions/CommentsExtension.php
@@ -495,15 +495,13 @@ class CommentsExtension extends DataExtension {
 	protected function updateModerationFields(FieldList $fields) {
 		Requirements::css(COMMENTS_DIR . '/css/cms.css');
 
-		$commentsConfig = CommentsGridFieldConfig::create();
-
 		$newComments = $this->owner->AllComments()->filter('Moderated', 0);
 
 		$newGrid = new CommentsGridField(
 			'NewComments',
 			_t('CommentsAdmin.NewComments', 'New'),
 			$newComments,
-			$commentsConfig
+			CommentsGridFieldConfig::create()
 		);
 
 		$approvedComments = $this->owner->AllComments()->filter('Moderated', 1)->filter('IsSpam', 0);
@@ -512,7 +510,7 @@ class CommentsExtension extends DataExtension {
 			'ApprovedComments',
 			_t('CommentsAdmin.Comments', 'Approved'),
 			$approvedComments,
-			$commentsConfig
+			CommentsGridFieldConfig::create()
 		);
 
 		$spamComments = $this->owner->AllComments()->filter('Moderated', 1)->filter('IsSpam', 1);
@@ -521,7 +519,7 @@ class CommentsExtension extends DataExtension {
 			'SpamComments',
 			_t('CommentsAdmin.SpamComments', 'Spam'),
 			$spamComments,
-			$commentsConfig
+			CommentsGridFieldConfig::create()
 		);
 
 		$newCount = '(' . count($newComments) . ')';


### PR DESCRIPTION
This is because the GridField constructor will add the state component to any config that is passed in; Meaning by the time a config is used three times it has three state components attached. =/

We should fix this in core, really. Maybe:
 - Gridfield only adds the component if it isn't already added
 - Or GridFieldConfig adds the state in its own constructor