### PR TITLE
FIX: Add missing parameters for nested comments to example configuration

### DIFF
--- a/docs/en/Configuration.md
+++ b/docs/en/Configuration.md
@@ -51,6 +51,8 @@ SiteTree:
       - i
       - b
     use_preview: false # preview formatted comment (when allowing HTML). Requires include_js=true
+    nested_comments: false # If true comments can be replied to up to nested_depth levels
+    nested_depth: 2 # The maximum depth of the comment hierarchy for comment reply purposes
 ```
 
 Enabling any of the *_cms options will instead allow these options to be configured under the settings tab


### PR DESCRIPTION
Documentation fix for https://github.com/silverstripe/silverstripe-comments/issues/156