### PR TITLE
Update version of related package in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ See docs/en/Installing.md
 
 ## Related
 
- * [tractorcow/silverstripe-comments-notifications](https://github.com/tractorcow/silverstripe-comments-notifications): Comment admin email notifications module
+ * [silverstripe/silverstripe-comments-notifications](https://github.com/silverstripe/silverstripe-comments-notifications): Comment admin email notifications module
 
 ## Contributing
 


### PR DESCRIPTION
The original package tractorcow/silverstripe-comments-notifications is now under the wing of SilverStripe.  As such change package name to silverstripe/silverstripe-comments-notifications.