### PR TITLE
FIX: Take account of spam/moderation status when enabling replies

### DIFF
--- a/code/model/Comment.php
+++ b/code/model/Comment.php
@@ -665,8 +665,9 @@ class Comment extends DataObject {
 		}
 
 		// Check if depth is limited
-		$maxLevel = $this->getOption('nested_depth');
-		return !$maxLevel || $this->Depth < $maxLevel;
+ 		$maxLevel = $this->getOption('nested_depth');
+ 		$notSpam = ($this->SpamClass() == 'notspam');
+		return $notSpam && (!$maxLevel || $this->Depth < $maxLevel);
 	}
 
 	/**

--- a/tests/CommentsTest.php
+++ b/tests/CommentsTest.php
@@ -966,6 +966,25 @@ class CommentsTest extends FunctionalTest {
 
         $comment->Depth = 4;
         $this->assertFalse($comment->getRepliesEnabled());
+
+
+        // 0 indicates no limit for nested_depth
+        Config::inst()->update('CommentableItem', 'comments', array(
+            'nested_comments' => true,
+            'nested_depth' => 0
+        ));
+
+        $comment->Depth = 234;
+        $this->assertTrue($comment->getRepliesEnabled());
+        $comment->markUnapproved();
+        $this->assertFalse($comment->getRepliesEnabled());
+        $comment->markSpam();
+        $this->assertFalse($comment->getRepliesEnabled());
+
+        $comment->markApproved();
+        $this->assertTrue($comment->getRepliesEnabled());
+
+
     }
 
     public function testAllReplies() {


### PR DESCRIPTION
Add a 'not spam' check for enabling comment replies.  Update tests accordingly.

Also added a test for unlimited nesting (nested_depth = 0)