### PR TITLE
FIX: NON JS page now has a 'Reply To' link, click to load page with form

### DIFF
--- a/code/controllers/CommentingController.php
+++ b/code/controllers/CommentingController.php
@@ -629,7 +629,7 @@ class CommentingController extends Controller
         } elseif (!$comment->Moderated) {
             // Display the "awaiting moderation" text
             $holder = $this->getOption('comments_holder_id');
-            $hash = "{$holder}_PostCommentForm_error";
+            $hash = "moderated";
         } else {
             // Link to the moderated, non-spam comment
             $hash = $comment->Permalink();

--- a/code/extensions/CommentsExtension.php
+++ b/code/extensions/CommentsExtension.php
@@ -480,6 +480,22 @@ class CommentsExtension extends DataExtension
             ->renderWith('CommentsInterface');
     }
 
+    /*
+    JavaScript form reply requires an empty form, when the reply button is
+    clicked the correct values are inserted, the form moved, and then shown
+     */
+    public function getReplyFormForJavaScript() {
+        // Build reply controller
+        $controller = CommentingController::create();
+        $controller->setOwnerRecord($this->owner);
+        $controller->setBaseClass($this->owner->ClassName);
+        $controller->setOwnerController(Controller::curr());
+        $comment = new Comment();
+        $comment->ID='JSOnly';
+        $comment->ParentID = $this->owner->ID;
+        return $controller->ReplyForm($comment);
+    }
+
     /**
      * Returns whether this extension instance is attached to a {@link SiteTree} object
      *

--- a/code/model/Comment.php
+++ b/code/model/Comment.php
@@ -46,7 +46,7 @@ class Comment extends DataObject
     );
 
     private static $has_many = array(
-        "ChildComments"    => "Comment"
+        "ChildComments" => "Comment"
     );
 
     private static $default_sort = '"Created" DESC';
@@ -732,6 +732,17 @@ class Comment extends DataObject
 
         $this->extend('updateAllReplies', $list);
         return $list;
+    }
+
+    /**
+     * Ascertains whether or not to show the reply form
+     */
+    public function ShowReplyToForm() {
+        $controller = Controller::curr();
+        $request = $controller->getRequest();
+        $replyTo = $request->getVar('replyTo');
+        $result = $replyTo == $this->ID;
+        return $result;
     }
 
     /**

--- a/javascript/lang/en.js
+++ b/javascript/lang/en.js
@@ -6,5 +6,7 @@ if (typeof(ss) == 'undefined' || typeof(ss.i18n) == 'undefined') {
     ss.i18n.addDictionary('en', {
         "CommentsInterface_singlecomment_ss.DELETE_CONFIRMATION": "Are you sure?",
         "CommentsInterface_singlecomment_ss.AJAX_ERROR": "An error occurred whilst updating the comment",
+        "CommentsInterface_singlecomment_ss.REPLY_TO" : "Reply to",
+        "CommentsInterface_singlecomment_ss.CANCEL_REPLY" : "Cancel Reply",
     });
 }

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -61,6 +61,8 @@ en:
     ISSPAM: 'spam it'
     PBY: 'Posted by'
     REMCOM: 'reject it'
+    REPLY_TO: 'Reply to'
+    CANCEL_REPLY: 'Cancel Reply'
   CommentsInterface_ss:
     AWAITINGMODERATION: 'Your comment has been submitted and is now awaiting moderation.'
     COMMENTLOGINERROR: 'You cannot post comments until you have logged in'

--- a/templates/CommentReplies.ss
+++ b/templates/CommentReplies.ss
@@ -1,10 +1,10 @@
 <% if $RepliesEnabled %>
 	<div class="comment-replies-container">
-		
 		<div class="comment-reply-form-holder">
-			$ReplyForm
+            <%-- non ajax, only show if replyTo is set --%>
+            <% if $ShowReplyToForm %>$ReplyForm<% end_if %>
 		</div>
-	
+
 		<div class="comment-replies-holder">
 			<% if $Replies %>
 				<ul class="comments-list level-{$Depth}">

--- a/templates/CommentsInterface.ss
+++ b/templates/CommentsInterface.ss
@@ -25,7 +25,7 @@
 			<% if $PagedComments %>
 				<ul class="comments-list root-level">
 					<% loop $PagedComments %>
-						<li class="comment $EvenOdd<% if FirstLast %> $FirstLast <% end_if %> $SpamClass">
+                        <li class="comment $EvenOdd<% if FirstLast %> $FirstLast <% end_if %> $SpamClass">
 							<% include CommentsInterface_singlecomment %>
 						</li>
 					<% end_loop %>
@@ -51,3 +51,5 @@
 		</p>
 	</div>
 <% end_if %>
+<%-- include a hidden form for JS use when replying --%>
+<div id="replyFormJS" style="display:none;">$ReplyFormForJavaScript</div>

--- a/templates/CommentsInterface_singlecomment.ss
+++ b/templates/CommentsInterface_singlecomment.ss
@@ -33,10 +33,12 @@
 				<% end_if %>
 			</div>
 			<% if $RepliesEnabled %>
-				<a class="comment-reply-link" href="#{$ReplyForm.FormName}">Reply to $AuthorName.XML</a>
+				<a data-comment-id="$ID" class="comment-reply-link" href="$Parent.Link?replyTo=$ID#Form_ReplyForm_$ID"><% _t('CommentsInterface_singlecomment_ss.REPLY_TO','Reply to') %>&nbsp;$AuthorName.XML</a>
 			<% end_if %>
 		</div>
 	<% end_if %>
+
+    <div class="comment-replies-container" id="reply-form-container-$ID"></div>
 
 	<% include CommentReplies %>
 <% end_if %>


### PR DESCRIPTION
Clicking on the 'Reply To' link reloads a page with a Reply To form appearing in the correct place.  An anchor is added to the redirected URL to ensure that the form is visible in context.

Fix for https://github.com/silverstripe/silverstripe-comments/issues/169
