### PR TITLE
BUG: Fix infinite loop in requireDefaultRecords()

### DIFF
--- a/code/model/Comment.php
+++ b/code/model/Comment.php
@@ -132,7 +132,7 @@ class Comment extends DataObject
             $comments = DB::query('SELECT * FROM "PageComment"');
 
             if ($comments) {
-                while ($pageComment = $comments->nextRecord()) {
+                while ($pageComment = $comments->next()) {
                     // create a new comment from the older page comment
                     $comment = new Comment();
                     $comment->update($pageComment);


### PR DESCRIPTION
Calling nextRecord() returns the first record again and again, resulting in an infinite loop. Call next() instead.