### PR TITLE
Extended translation support

### DIFF
--- a/code/admin/CommentsGridFieldAction.php
+++ b/code/admin/CommentsGridFieldAction.php
@@ -53,7 +53,7 @@ class CommentsGridFieldAction implements GridField_ColumnProvider, GridField_Act
             $field .= GridField_FormAction::create(
                 $gridField,
                 'CustomAction' . $record->ID . 'Spam',
-                'Spam',
+                _t('CommentsGridFieldAction.SPAM', 'Spam'),
                 'spam',
                 array('RecordID' => $record->ID)
             )->Field();
@@ -63,7 +63,7 @@ class CommentsGridFieldAction implements GridField_ColumnProvider, GridField_Act
             $field .= GridField_FormAction::create(
                 $gridField,
                 'CustomAction' . $record->ID . 'Approve',
-                'Approve',
+                _t('CommentsGridFieldAction.APPROVE', 'Approve'),
                 'approve',
                 array('RecordID' => $record->ID)
             )->Field();
@@ -92,7 +92,7 @@ class CommentsGridFieldAction implements GridField_ColumnProvider, GridField_Act
             // output a success message to the user
             Controller::curr()->getResponse()->setStatusCode(
                 200,
-                'Comment marked as spam.'
+                _t('CommentsGridFieldAction.COMMENTMARKEDSPAM', 'Comment marked as spam.')
             );
         }
 
@@ -103,7 +103,7 @@ class CommentsGridFieldAction implements GridField_ColumnProvider, GridField_Act
             // output a success message to the user
             Controller::curr()->getResponse()->setStatusCode(
                 200,
-                'Comment approved.'
+                _t('CommentsGridFieldAction.COMMENTAPPROVED', 'Comment approved.')
             );
         }
     }

--- a/code/admin/CommentsGridFieldConfig.php
+++ b/code/admin/CommentsGridFieldConfig.php
@@ -26,7 +26,9 @@ class CommentsGridFieldConfig extends GridFieldConfig_RecordEditor
         $manager = new GridFieldBulkManager();
 
         $manager->addBulkAction(
-            'spam', 'Spam', 'CommentsGridFieldBulkAction_Handlers',
+            'spam', 
+            _t('CommentsGridFieldConfig.SPAM', 'Spam'), 
+            'CommentsGridFieldBulkAction_Handlers',
             array(
                 'isAjax' => true,
                 'icon' => 'cross',
@@ -35,7 +37,9 @@ class CommentsGridFieldConfig extends GridFieldConfig_RecordEditor
         );
 
         $manager->addBulkAction(
-            'approve', 'Approve', 'CommentsGridFieldBulkAction_Handlers',
+            'approve', 
+            _t('CommentsGridFieldConfig.APPROVE', 'Approve'), 
+            'CommentsGridFieldBulkAction_Handlers',
             array(
                 'isAjax' => true,
                 'icon' => 'cross',

--- a/code/model/Comment.php
+++ b/code/model/Comment.php
@@ -576,7 +576,7 @@ class Comment extends DataObject
                 ->obj('Created')
                 ->scaffoldFormField($this->fieldLabel('Created'))
                 ->performReadonlyTransformation(),
-            TextField::create('Name', $this->fieldLabel('AuthorName')),
+            TextField::create('Name', $this->fieldLabel('Name')),
             $commentField::create('Comment', $this->fieldLabel('Comment')),
             EmailField::create('Email', $this->fieldLabel('Email')),
             TextField::create('URL', $this->fieldLabel('URL')),
@@ -584,7 +584,7 @@ class Comment extends DataObject
                 CheckboxField::create('Moderated', $this->fieldLabel('Moderated')),
                 CheckboxField::create('IsSpam', $this->fieldLabel('IsSpam')),
             ))
-                ->setTitle('Options')
+                ->setTitle(_t('Comment.OPTIONS', 'Options'))
                 ->setDescription(_t(
                     'Comment.OPTION_DESCRIPTION',
                     'Unmoderated and spam comments will not be displayed until approved'

--- a/tests/CommentAdminTest.php
+++ b/tests/CommentAdminTest.php
@@ -2,6 +2,9 @@
 
 class CommentAdminTest extends SapphireTest
 {
+
+    protected $usesDatabase = true;
+    
     public function testProvidePermissions()
     {
         $commentAdmin = new CommentAdmin();


### PR DESCRIPTION
Added translation support for CommentsAdmin's inline spam/approve marking labels, and also for the success messages (controller response), and also for the bulk action labels (shown in drop down).

I'm new to contributing so please bear with me and feel free to correct me if I'm doing something I shouldn't be. 💫 