### PR TITLE
FIX endless redirect while moderating comments

### DIFF
--- a/code/controllers/CommentingController.php
+++ b/code/controllers/CommentingController.php
@@ -263,7 +263,17 @@ class CommentingController extends Controller
             return $this->httpError(400);
         }
 
-        $comment->markSpam();
+        if (!$comment->Moderated) {
+            $comment->markSpam();
+        }
+
+        // prevent endless loop of redirects if this request has been made without being logged on
+        $referer = $this->request->getHeader('Referer');
+        if (strpos($referer,"/Security/login") !== false) {
+            echo "Comment marked as spam";
+            return ;
+        }
+
         return $this->renderChangedCommentState($comment);
     }
 
@@ -283,7 +293,17 @@ class CommentingController extends Controller
             return $this->httpError(400);
         }
 
-        $comment->markApproved();
+        if (!$comment->Moderated) {
+            $comment->markApproved();
+        }
+
+        // prevent endless loop of redirects if this request has been made without being logged on
+        $referer = $this->request->getHeader('Referer');
+        if (strpos($referer,"/Security/login") !== false) {
+            echo "Comment approved";
+            return ;
+        }
+
         return $this->renderChangedCommentState($comment);
     }
 
@@ -303,7 +323,17 @@ class CommentingController extends Controller
             return $this->httpError(400);
         }
 
-        $comment->markApproved();
+        if (!$comment->Moderated) {
+            $comment->markApproved();
+        }
+
+        // prevent endless loop of redirects if this request has been made without being logged on
+        $referer = $this->request->getHeader('Referer');
+        if (strpos($referer,"/Security/login") !== false) {
+            echo "Comment approved";
+            return ;
+        }
+
         return $this->renderChangedCommentState($comment);
     }
 


### PR DESCRIPTION
Moderating comments using links in an email message causes the user to end up in an infinite redirect loop.

How to reproduce;
1. create a direct link that allows you to moderate a comment
2. make sure you're not logged-on to the cms and open the previous link.
3. the user is redirected to the logon-page
4. after logging in, the user is redirected to the previous page (moderate comment)
5. after moderation; the user is redirected back to the previous page. In this case the logon page... and so on...
