### PR TITLE
FIX Remove providePermissions tests and update Travis build configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,13 @@ php:
   - 5.3
   - 5.4
   - 5.5
-  - 5.6
-  - 7.0
 
 before_install:
   - pip install --user codecov
 
 env:
   global:
-    - DB=MYSQL CORE_RELEASE=3.1
+    - DB=MYSQL CORE_RELEASE=3.5
     - MODULE_PATH=comments
 
     # Set to 1 in the matrix to enable code coverage
@@ -29,15 +27,13 @@ matrix:
   include:
     - php: 5.6
       #CommentsListTest breaks with this env: DB=MYSQL CORE_RELEASE=3.2 COVERAGE=1
-      env: DB=SQLITE CORE_RELEASE=3.2 COVERAGE=1
+      env: DB=SQLITE CORE_RELEASE=3.5 COVERAGE=1
+    - php: 7.1
+      env: DB=MYSQL CORE_RELEASE=3.6
     - php: 5.6
+      env: DB=PGSQL CORE_RELEASE=3.5
+    - php: 7.1
       env: DB=MYSQL CORE_RELEASE=3
-    - php: 5.6
-      env: DB=MYSQL CORE_RELEASE=3.1
-    - php: 5.6
-      env: DB=PGSQL CORE_RELEASE=3.2
-  allow_failures:
-    - php: 7.0
 
 before_script:
   - phpenv rehash

--- a/tests/CommentAdminTest.php
+++ b/tests/CommentAdminTest.php
@@ -2,34 +2,7 @@
 
 class CommentAdminTest extends SapphireTest
 {
-
     protected $usesDatabase = true;
-    
-    public function testProvidePermissions()
-    {
-        $commentAdmin = new CommentAdmin();
-        $locale = i18n::get_locale();
-
-        i18n::set_locale('fr');
-        $expected = array(
-            'CMS_ACCESS_CommentAdmin' => array(
-                # FIXME - this is a bug, missing from lang.yml files
-                'name' => 'Access to \'Comments\' section',
-                'category' => 'Accès au CMS'
-            )
-        );
-        $this->assertEquals($expected, $commentAdmin->providePermissions());
-
-        i18n::set_locale($locale);
-        $expected = array(
-            'CMS_ACCESS_CommentAdmin' => array(
-                # FIXME - this is a bug, missing from lang.yml files
-                'name' => 'Access to \'Comments\' section',
-                'category' => 'CMS Access'
-            )
-        );
-        $this->assertEquals($expected, $commentAdmin->providePermissions());
-    }
 
     public function testGetEditForm()
     {


### PR DESCRIPTION
This PR removes the `testProvidePermissions` test case because:

* It is testing a translation that doesn't necessarily exist (and is not mocked in the test)
* It is testing a core translation that is not relevant to this module

The method it tests doesn't have any module specific logic, so I've removed the test completely.

---

Also, updated the Travis build configuration to build PHP 5.3 to 7.1 with MySQL, PGSQL and SQLite on SS 3.5, 3.6 and 3.x

Resolves #205 