### PR TITLE
FIX: update javascript requirements so user JS doesn't error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         },
         "expose": [
             "css",
-            "javascript"
+            "javascript",
+            "thirdparty"
         ]
     },
     "scripts": {

--- a/docs/en/Configuration.md
+++ b/docs/en/Configuration.md
@@ -70,8 +70,10 @@ SilverStripe\CMS\Model\SiteTree:
 
 
 ```php
-// Get the setting
-$loginRequired = singleton('SilverStripe\\CMS\\Model\\SiteTree')->getCommentsOption('require_login');
+use SilverStripe\CMS\Model\SiteTree;
+// [...]
+  // Get the setting
+  $loginRequired = singleton(SiteTree::class)->getCommentsOption('require_login');
 ```
 
 
@@ -87,9 +89,9 @@ In order to use this feature, you need to install the
 through [Composer](http://getcomposer.org).
 
 ```json
-    {
-        "require": {"ezyang/htmlpurifier": "^4.8"}
-    }
+{
+    "require": {"ezyang/htmlpurifier": "^4.8"}
+}
 ```
 
 **Important**: Rendering user-provided HTML on your website always risks
@@ -148,7 +150,7 @@ SilverStripe\CMS\Model\SiteTree:
     gravatar_rating: 'r'
 ```
 
-Vald values for rating are as follows:
+Valid values for rating are as follows:
 
 * g: suitable for display on all websites with any audience type.
 * pg: may contain rude gestures, provocatively dressed individuals, the lesser

--- a/docs/en/Installing.md
+++ b/docs/en/Installing.md
@@ -1,26 +1,12 @@
 # Installation
 
-## Composer
-
-Edit your project-wide composer.json file as follows; in the "require" block add:
-
-	"silverstripe/comments": "*"
-
 Then in the root of your project run:
 
-	#> composer update silverstripe/comments
+```sh
+composer require silverstripe/comments`
+```
 
-## Web
-
-To begin the installation first download the module online. You can find the version you require for your SilverStripe installation on the [silverstripe.org](http://www.silverstripe.org) website.
-
-After you have finished downloading the file, extract the downloaded file to your site's root folder and ensure the name of the module is `comments`.
-
-## All
-
-Run a database rebuild by visiting *http://yoursite.com/dev/build?flush=1*. This will add the required database columns and tables for the module to function, and refresh the configuration manifest.
-
-If you previously had SilverStripe version 2.4 installed then you'll also need to run the migration script provided. More information on this is provided in the next section.
+Then run a database rebuild by visiting `dev/build`. This will add the required database columns and tables for the module to function, and refresh the configuration manifest.
 
 ## Enabling Commenting
 
@@ -30,8 +16,6 @@ For more configuration options see [Configuration](Configuration.md).
 
 ## Upgrading
 
-### Migrating from version 2.* SilverStripe installations
+### Migrating from version SilverStripe 2 installations
 
-This module replaces the built-in commenting system available in versions up to SilverStripe 2.4. To migrate from that you'll need to run `dev/build` after installing the module.
-
-You can do this via sake (`sake dev/build flush=1`) or via a web browser by visiting `http://yoursite.com/dev/build?flush=1`
+This module replaces the built-in commenting system available in SilverStripe 2. Running the `dev/build` task will automatically perform a migration if any comments from these old versions exist.

--- a/docs/en/Installing.md
+++ b/docs/en/Installing.md
@@ -13,9 +13,3 @@ Then run a database rebuild by visiting `dev/build`. This will add the required 
 Out of the box the module adds commenting support to all pages on your site. This functionality can be turned on and off on a per page basis in the CMS under the `Behaviour` tab for a given page. Once the `Allow Comments` checkbox is ticked, republish and view the webpage.
 
 For more configuration options see [Configuration](Configuration.md).
-
-## Upgrading
-
-### Migrating from version SilverStripe 2 installations
-
-This module replaces the built-in commenting system available in SilverStripe 2. Running the `dev/build` task will automatically perform a migration if any comments from these old versions exist.

--- a/src/Admin/CommentsGridFieldConfig.php
+++ b/src/Admin/CommentsGridFieldConfig.php
@@ -35,7 +35,7 @@ class CommentsGridFieldConfig extends GridFieldConfig_RecordEditor
 
         $manager->addBulkAction(
             'spam',
-            _t('SilverStripe\\Comments\\Admin\\CommentsGridFieldConfig.SPAM', 'Spam'),
+            _t(__CLASS__ . '.SPAM', 'Spam'),
             Handler::class,
             array(
                 'isAjax' => true,
@@ -46,7 +46,7 @@ class CommentsGridFieldConfig extends GridFieldConfig_RecordEditor
 
         $manager->addBulkAction(
             'approve',
-            _t('SilverStripe\\Comments\\Admin\\CommentsGridFieldConfig.APPROVE', 'Approve'),
+            _t(__CLASS__ . '.APPROVE', 'Approve'),
             Handler::class,
             array(
                 'isAjax' => true,

--- a/src/Controllers/CommentingController.php
+++ b/src/Controllers/CommentingController.php
@@ -274,7 +274,7 @@ class CommentingController extends Controller
             }
         }
 
-        $title = _t('SilverStripe\\Comments\\Controllers\\CommentingController.RSSTITLE', "Comments RSS Feed");
+        $title = _t(__CLASS__ . '.RSSTITLE', "Comments RSS Feed");
         $comments = new PaginatedList($comments, $request);
         $comments->setPageLength($this->getOption('comments_per_page'));
 

--- a/src/Extensions/CommentsExtension.php
+++ b/src/Extensions/CommentsExtension.php
@@ -184,7 +184,7 @@ class CommentsExtension extends DataExtension
                 'None' => _t(__CLASS__ . '.MODERATIONREQUIRED_NONE', 'No moderation required'),
                 'Required' => _t(__CLASS__ . '.MODERATIONREQUIRED_REQUIRED', 'Moderate all comments'),
                 'NonMembersOnly' => _t(
-                    'SilverStripe\\Comments\\Extensions\\CommentsExtension.MODERATIONREQUIRED_NONMEMBERSONLY',
+                    __CLASS__ . '.MODERATIONREQUIRED_NONMEMBERSONLY',
                     'Only moderate non-members'
                 ),
             ));
@@ -450,11 +450,11 @@ class CommentsExtension extends DataExtension
         // Check if enabled
         $enabled = $this->getCommentsEnabled();
         if ($enabled && $this->owner->getCommentsOption('include_js')) {
-            $adminThirdPartyDir = ModuleLoader::getModule('silverstripe/admin')->getRelativePath() . '/thirdparty';
-            Requirements::javascript($adminThirdPartyDir . '/jquery/jquery.js');
-            Requirements::javascript($adminThirdPartyDir . '/jquery-entwine/dist/jquery.entwine-dist.js');
-            Requirements::javascript($adminThirdPartyDir . '/jquery-form/jquery.form.js');
+            Requirements::javascript('silverstripe/admin:thirdparty/jquery/jquery.js');
+            Requirements::javascript('silverstripe/admin:thirdparty/jquery-entwine/dist/jquery.entwine-dist.js');
+            Requirements::javascript('silverstripe/admin:thirdparty/jquery-form/jquery.form.js');
             Requirements::javascript('silverstripe/comments:thirdparty/jquery-validate/jquery.validate.min.js');
+            Requirements::javascript('silverstripe/admin:client/dist/js/i18n.js');
             Requirements::add_i18n_javascript('silverstripe/comments:javascript/lang');
             Requirements::javascript('silverstripe/comments:javascript/CommentsInterface.js');
         }

--- a/src/Model/Comment.php
+++ b/src/Model/Comment.php
@@ -182,39 +182,6 @@ class Comment extends DataObject
     }
 
     /**
-     * Migrates the old {@link PageComment} objects to {@link Comment}
-     */
-    public function requireDefaultRecords()
-    {
-        parent::requireDefaultRecords();
-
-        // Upgrade from SilverStripe 2 version if necessary
-        if (DB::get_schema()->hasTable('PageComment')) {
-            $comments = DB::query('SELECT * FROM "PageComment"');
-
-            if ($comments) {
-                while ($pageComment = $comments->next()) {
-                    // create a new comment from the older page comment
-                    $comment = new Comment();
-                    $comment->update($pageComment);
-
-                    // set the variables which have changed
-                    $comment->BaseClass = SiteTree::class;
-                    $comment->URL = (isset($pageComment['CommenterURL'])) ? $pageComment['CommenterURL'] : '';
-                    if ((int) $pageComment['NeedsModeration'] == 0) {
-                        $comment->Moderated = true;
-                    }
-
-                    $comment->write();
-                }
-            }
-
-            DB::alteration_message('Migrated PageComment to Comment', 'changed');
-            DB::get_schema()->dontRequireTable('PageComment');
-        }
-    }
-
-    /**
      * Return a link to this comment
      *
      * @param string $action

--- a/src/Model/Comment.php
+++ b/src/Model/Comment.php
@@ -188,6 +188,7 @@ class Comment extends DataObject
     {
         parent::requireDefaultRecords();
 
+        // Upgrade from SilverStripe 2 version if necessary
         if (DB::get_schema()->hasTable('PageComment')) {
             $comments = DB::query('SELECT * FROM "PageComment"');
 


### PR DESCRIPTION
The JS relies on i18n.js which is not part of a build bundle in `silverstripe/admin`. There is a shim file for legacy style modules that depend on it though which we can use in a stand alone manner to re-enable support for the translations in this module. The front-end javascript (included by default) now no longer presents an error preventing other JS on the page running.

Fixes #226 