### PR TITLE
Improve A11y of comment reply.

### DIFF
--- a/javascript/CommentsInterface.js
+++ b/javascript/CommentsInterface.js
@@ -79,20 +79,25 @@
 		 * Toggle on/off reply form
 		 */
 		$( ".comment-reply-link" ).entwine({
-			onclick: function( e ) {
-				var allForms = $( ".comment-reply-form-holder" ),
-					formID = $( this ).prop('href').replace(/^[^#]*#/, '#'),
+		        onclick: function( e ) {
+					var allForms = $( ".comment-reply-form-holder" ),
+					formID = '#' + $( this ).attr('aria-controls');
 					form = $(formID).closest('.comment-reply-form-holder');
 
-				// Prevent focus
-				e.preventDefault();
-				if(form.is(':visible')) {
-					allForms.slideUp();
-				} else {
-					allForms.not(form).slideUp();
+					$(this).attr('aria-expanded', function (i, attr) {
+					    return attr == 'true' ? 'false' : 'true'
+					});
+
+					// Prevent focus
+					e.preventDefault();
+					
+					if(form.is(':visible')) {
+						allForms.slideUp();
+					} else {
+						allForms.not(form).slideUp();
 					form.slideDown();
-				}
-			}
+		      	}
+		    }
 		});
 
 

--- a/templates/Includes/CommentsInterface_singlecomment.ss
+++ b/templates/Includes/CommentsInterface_singlecomment.ss
@@ -33,7 +33,9 @@
 				<% end_if %>
 			</div>
 			<% if $RepliesEnabled && $canPostComment %>
-				<a class="comment-reply-link" href="#{$ReplyForm.FormName}"><% _t('CommentsInterface_singlecomment_ss.REPLYTO','Reply to') %> $AuthorName.XML</a>
+				<button class="comment-reply-link" type="button" aria-controls="$ReplyForm.FormName" aria-expanded="false">
++					<% _t('CommentsInterface_singlecomment_ss.REPLYTO','Reply to') %> $AuthorName.XML
++				</button>
 			<% end_if %>
 		</div>
 	<% end_if %>


### PR DESCRIPTION
Hi there,

I work for the Govt Info Services teams at Dept Internal Affairs.

Recently we commissioned an A11y audit of one of our sites that uses this module.

The changes, in this merge request for your consideration, are what we implemented based on that reports suggested solution. 

I'll quote the rationale below. I'm happy to discuss it although I'm not the author of the recommendation I can try get any questions/concerns addressed by the author.

Quoted Rationale: 
===> Starts
Currently [the reply to a commenter functionality] is a link. Users will expect this link to take them to another part of the page or another page altogether. 

There is no indication that it opens or closes an associated form on the same page, nor does it indicate the current state of the “reply to” form.

So, instead of a link, use a button. Add to that button an aria-controls attribute that references the id of the associated form’s container, and an aria-expanded attribute that indicates (true or false) the state of the associated form."

ends <===

Regards,
Ben Wrighton
Dev @ GIS, DIA