### PR TITLE
remove ability to pull in with an ss4 project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "assertchris/hash-compat": "~1.0",
-        "silverstripe/framework": "~3.1",
+        "silverstripe/framework": "^3.1",
         "colymba/gridfield-bulk-editing-tools": "~2.1"
     },
     "suggest": {


### PR DESCRIPTION
Stops `composer update` pulling in 2.1 on an SS4 project