### PR TITLE
FIX backport fix for lack of HTMLPurifier breakage

### DIFF
--- a/code/model/Comment.php
+++ b/code/model/Comment.php
@@ -649,8 +649,10 @@ class Comment extends DataObject
      */
     public function purifyHtml($dirtyHtml)
     {
-        $purifier = $this->getHtmlPurifierService();
-        return $purifier->purify($dirtyHtml);
+        if ($service = $this->getHtmlPurifierService()) {
+            return $service->purify($dirtyHtml);
+        }
+        return $dirtyHtml;
     }
 
     /**
@@ -658,6 +660,10 @@ class Comment extends DataObject
      */
     public function getHtmlPurifierService()
     {
+        if (!class_exists('HTMLPurifier_Config')) {
+            return null;
+        }
+
         $config = HTMLPurifier_Config::createDefault();
         $allowedElements = $this->getOption('html_allowed_elements');
         $config->set('HTML.AllowedElements', $allowedElements);


### PR DESCRIPTION
If HTMLPurifier is missing, a fatal error is giving for a missing class.
This results in comments essentially not working. The fix is simple and
has already been done in 2.0 - as the package is optional we can simply
check if the classname exists before trying to use it, or do nothing.