### PR TITLE
API Reintroduce abstract handler (previously removed in 192ddbb) and deprecate for future removal

### DIFF
--- a/src/Admin/CommentsGridFieldBulkAction/Handler.php
+++ b/src/Admin/CommentsGridFieldBulkAction/Handler.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace SilverStripe\Comments\Admin\CommentsGridFieldBulkAction;
+
+use Colymba\BulkManager\BulkAction\Handler as GridFieldBulkActionHandler;
+use SilverStripe\Core\Convert;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\HTTPResponse;
+
+/**
+ * A {@link GridFieldBulkActionHandler} for bulk marking comments as spam
+ *
+ * @deprecated 3.1..4.0 Abstract handlers are removed, please use concrete Spam or Approve handlers
+ */
+class Handler extends GridFieldBulkActionHandler
+{
+    private static $allowed_actions = array(
+        'spam',
+        'approve',
+    );
+
+    private static $url_handlers = array(
+        'spam' => 'spam',
+        'approve' => 'approve',
+    );
+
+    /**
+     * @param  HTTPRequest $request
+     * @return HTTPResponse
+     */
+    public function spam(HTTPRequest $request)
+    {
+        $ids = array();
+
+        foreach ($this->getRecords() as $record) {
+            array_push($ids, $record->ID);
+            $record->markSpam();
+        }
+
+        $response = new HTTPResponse(Convert::raw2json(array(
+            'done' => true,
+            'records' => $ids
+        )));
+
+        $response->addHeader('Content-Type', 'text/json');
+
+        return $response;
+    }
+
+    /**
+     * @param  HTTPRequest $request
+     * @return HTTPResponse
+     */
+    public function approve(HTTPRequest $request)
+    {
+        $ids = array();
+
+        foreach ($this->getRecords() as $record) {
+            array_push($ids, $record->ID);
+            $record->markApproved();
+        }
+
+        $response = new HTTPResponse(Convert::raw2json(array(
+            'done' => true,
+            'records' => $ids
+        )));
+
+        $response->addHeader('Content-Type', 'text/json');
+
+        return $response;
+    }
+}


### PR DESCRIPTION
This is to ensure we can release 3.1.0 on the master branch without having to break semver, since this class removal was a breaking change.