### PR TITLE
FIX reintroduce extension hook for comment form rendering

### DIFF
--- a/src/Controllers/CommentingController.php
+++ b/src/Controllers/CommentingController.php
@@ -475,7 +475,12 @@ class CommentingController extends Controller
      */
     public function CommentsForm()
     {
-        return Injector::inst()->create(CommentForm::class, __FUNCTION__, $this);
+        $form = Injector::inst()->create(CommentForm::class, __FUNCTION__, $this);
+
+        // hook to allow further extensions to alter the comments form
+        $this->extend('alterCommentForm', $form);
+
+        return $form;
     }
 
 


### PR DESCRIPTION
In CWP 1.x there was an extension hook to allow alterations to the commenting form.
Since the upgrade of this module for CWP 2.x this was no longer there, meaning functionality
that relied upon it no longer worked. This commit reintroduces this functionality to keep
other modules that apply extensions to that hook, happy.

Resolves https://github.com/silverstripe/cwp/issues/68 and resolves https://github.com/silverstripe/silverstripe-spamprotection/issues/65