### PR TITLE
Fix Tests

### DIFF
--- a/tests/CommentsExtensionTest.php
+++ b/tests/CommentsExtensionTest.php
@@ -283,7 +283,7 @@ class CommentsExtensionTest extends FunctionalTest
         $expected = '<textarea name="Comment"';
         $this->assertContains($expected, $cf);
 
-        $expected = '<input type="submit" name="action_doPostComment" value="Post" class="action" id="comments-holder_action_doPostComment"';
+        $expected = '<input type="submit" name="action_doPostComment" value="Post" class="action"';
         $this->assertContains($expected, $cf);
 
         $expected = '/comments/spam/';


### PR DESCRIPTION
This resolves the current build failures by loosening the test for an expected form element. Recently the form ID of the comments form was updated which broke this test.

Resolves #251