### PR TITLE
Prevent storing formdata to cookies.

### DIFF
--- a/src/Forms/CommentForm.php
+++ b/src/Forms/CommentForm.php
@@ -2,7 +2,11 @@
 
 namespace SilverStripe\Comments\Forms;
 
+use SilverStripe\Comments\Controllers\CommentingController;
+use SilverStripe\Comments\Model\Comment;
+use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Core\Convert;
 use SilverStripe\Forms\CompositeField;
 use SilverStripe\Forms\EmailField;
 use SilverStripe\Forms\FieldList;
@@ -14,12 +18,7 @@ use SilverStripe\Forms\RequiredFields;
 use SilverStripe\Forms\TextareaField;
 use SilverStripe\Forms\TextField;
 use SilverStripe\Security\Member;
-use SilverStripe\Core\Convert;
 use SilverStripe\Security\Security;
-use SilverStripe\Comments\Model\Comment;
-use SilverStripe\Control\Controller;
-use SilverStripe\Comments\Controllers\CommentingController;
-use SilverStripe\Core\Config\Config;
 
 class CommentForm extends Form
 {
@@ -121,11 +120,11 @@ class CommentForm extends Form
 
             // we do not want to read a new URL when the form has already been submitted
             // which in here, it hasn't been.
-            $this->loadDataFrom(array(
+            $this->loadDataFrom([
                 'ParentID'        => $record->ID,
                 'ReturnURL'       => $controller->getRequest()->getURL(),
                 'ParentClassName' => $controller->getParentClass()
-            ));
+            ]);
         }
 
         // Set it so the user gets redirected back down to the form upon form fail
@@ -133,26 +132,27 @@ class CommentForm extends Form
 
         // load any data from the session
         $data = $this->getSessionData();
-        if (is_array($data)) {
+        if (!is_array($data)) {
+            return;
+        }
 
-            // load user data from previous form request back into form.
-            if (array_key_exists('UserData', $data)) {
-                $formData = Convert::json2array($data['UserData']);
+        // load user data from previous form request back into form.
+        if (array_key_exists('UserData', $data)) {
+            $formData = Convert::json2array($data['UserData']);
 
-                $this->loadDataFrom(array(
-                    'Name' => isset($formData['Name']) ? $formData['Name'] : '',
-                    'URL' => isset($formData['URL']) ? $formData['URL'] : '',
-                    'Email' => isset($formData['Email']) ? $formData['Email'] : ''
-                ));
-            }
+            $this->loadDataFrom([
+                'Name' => isset($formData['Name']) ? $formData['Name'] : '',
+                'URL' => isset($formData['URL']) ? $formData['URL'] : '',
+                'Email' => isset($formData['Email']) ? $formData['Email'] : ''
+            ]);
+        }
 
-            // allow previous value to fill if comment
-            if (array_key_exists('Comment', $data)) {
-                $prevComment = $data['Comment'];
+        // allow previous value to fill if comment
+        if (array_key_exists('Comment', $data)) {
+            $prevComment = $data['Comment'];
 
-                if ($prevComment && $prevComment != '') {
-                    $this->loadDataFrom(array('Comment' => $prevComment));
-                }
+            if ($prevComment && $prevComment != '') {
+                $this->loadDataFrom(['Comment' => $prevComment]);
             }
         }
     }
@@ -190,10 +190,10 @@ class CommentForm extends Form
         }
 
         // cache users data
-        $form->setSessionData(array(
+        $form->setSessionData([
             'UserData' => Convert::raw2json($data),
             'Comment' =>  $data['Comment']
-        ));
+        ]);
 
         // extend hook to allow extensions. Also see onAfterPostComment
         $this->controller->extend('onBeforePostComment', $form);
@@ -255,15 +255,15 @@ class CommentForm extends Form
         }
 
         // clear the users comment since the comment was successful.
-        if($comment->exists()){
+        if ($comment->exists()) {
             // Remove the comment data as it's been saved already.
             unset($data['Comment']);
         }
 
         // cache users data (name, email, etc to prepopulate on other forms).
-        $form->setSessionData(array(
+        $form->setSessionData([
             'UserData' => Convert::raw2json($data),
-        ));
+        ]);
 
         // Find parent link
         if (!empty($data['ReturnURL'])) {


### PR DESCRIPTION
XSS could be stored in a cookie and potentially abused in other ways, so
to prevent this we need to use session instead. This requires the user
to have a session, but this is better than saving potentially malicious content
in cookies. (Also some cookies have limited length).

@see https://github.com/silverstripe/silverstripe-comments/issues/263