### PR TITLE
Minor tidy ups to code formatting

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,17 +6,5 @@
     <rule ref="PSR2" >
         <!-- Current exclusions -->
         <exclude name="PSR1.Methods.CamelCapsMethodName" />
-        <exclude name="PSR1.Files.SideEffects.FoundWithSymbols" />
-        <exclude name="PSR2.Classes.PropertyDeclaration" />
-        <exclude name="PSR2.ControlStructures.SwitchDeclaration" /> <!-- causes php notice while linting -->
-        <exclude name="PSR2.ControlStructures.SwitchDeclaration.WrongOpenercase" />
-        <exclude name="PSR2.ControlStructures.SwitchDeclaration.WrongOpenerdefault" />
-        <exclude name="PSR2.ControlStructures.SwitchDeclaration.TerminatingComment" />
-        <exclude name="PSR2.Methods.MethodDeclaration.Underscore" />
-        <exclude name="Squiz.Scope.MethodScope" />
-        <exclude name="Squiz.Classes.ValidClassName.NotCamelCaps" />
-        <exclude name="Generic.Files.LineLength.TooLong" />
-        <exclude name="PEAR.Functions.ValidDefaultValue.NotAtEnd" />
     </rule>
-
 </ruleset>

--- a/src/Admin/CommentAdmin.php
+++ b/src/Admin/CommentAdmin.php
@@ -3,22 +3,19 @@
 namespace SilverStripe\Comments\Admin;
 
 use SilverStripe\Admin\LeftAndMain;
-use SilverStripe\Comments\Admin\CommentsGridField;
 use SilverStripe\Comments\Model\Comment;
-use SilverStripe\Forms\Tab;
-use SilverStripe\Forms\TabSet;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
-use SilverStripe\Security\PermissionProvider;
+use SilverStripe\Forms\Tab;
+use SilverStripe\Forms\TabSet;
 use SilverStripe\Security\Security;
-use SilverStripe\View\SSViewer;
 
 /**
  * Comment administration system within the CMS
  *
  * @package comments
  */
-class CommentAdmin extends LeftAndMain implements PermissionProvider
+class CommentAdmin extends LeftAndMain
 {
     private static $url_segment = 'comments';
 
@@ -28,7 +25,7 @@ class CommentAdmin extends LeftAndMain implements PermissionProvider
 
     private static $menu_icon_class = 'font-icon-comment';
 
-    private static $allowed_actions = array(
+    private static $allowed_actions = [
         'approvedmarked',
         'deleteall',
         'deletemarked',
@@ -37,18 +34,18 @@ class CommentAdmin extends LeftAndMain implements PermissionProvider
         'spammarked',
         'EditForm',
         'unmoderated'
-    );
+    ];
 
     private static $required_permission_codes = 'CMS_ACCESS_CommentAdmin';
 
     public function providePermissions()
     {
-        return array(
-            "CMS_ACCESS_CommentAdmin" => array(
+        return [
+            'CMS_ACCESS_CommentAdmin' => [
                 'name' => _t(__CLASS__ . '.ADMIN_PERMISSION', "Access to 'Comments' section"),
                 'category' => _t('SilverStripe\\Security\\Permission.CMS_ACCESS_CATEGORY', 'CMS Access')
-            )
-        );
+            ],
+        ];
     }
 
     /**
@@ -69,7 +66,7 @@ class CommentAdmin extends LeftAndMain implements PermissionProvider
 
         $newComments = Comment::get()->filter('Moderated', 0);
 
-        $newGrid = new CommentsGridField(
+        $newGrid = CommentsGridField::create(
             'NewComments',
             '',
             $newComments,
@@ -78,7 +75,7 @@ class CommentAdmin extends LeftAndMain implements PermissionProvider
 
         $approvedComments = Comment::get()->filter('Moderated', 1)->filter('IsSpam', 0);
 
-        $approvedGrid = new CommentsGridField(
+        $approvedGrid = CommentsGridField::create(
             'ApprovedComments',
             '',
             $approvedComments,
@@ -87,7 +84,7 @@ class CommentAdmin extends LeftAndMain implements PermissionProvider
 
         $spamComments = Comment::get()->filter('Moderated', 1)->filter('IsSpam', 1);
 
-        $spamGrid = new CommentsGridField(
+        $spamGrid = CommentsGridField::create(
             'SpamComments',
             '',
             $spamComments,
@@ -140,7 +137,7 @@ class CommentAdmin extends LeftAndMain implements PermissionProvider
         $form->setTemplate($this->getTemplatesWithSuffix('_EditForm'));
 
         if ($form->Fields()->hasTabset()) {
-             $form->Fields()->findOrMakeTab('Root')->setTemplate('SilverStripe\\Forms\\CMSTabSet');
+            $form->Fields()->findOrMakeTab('Root')->setTemplate('SilverStripe\\Forms\\CMSTabSet');
             $form->addExtraClass('center ss-tabset cms-tabset ' . $this->BaseCSSClasses());
         }
 

--- a/src/Admin/CommentsGridField.php
+++ b/src/Admin/CommentsGridField.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\Comments\Admin;
 
-use SilverStripe\Forms\FormField;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\View\HTML;
 

--- a/src/Admin/CommentsGridFieldAction.php
+++ b/src/Admin/CommentsGridFieldAction.php
@@ -26,7 +26,7 @@ class CommentsGridFieldAction implements GridField_ColumnProvider, GridField_Act
      */
     public function getColumnAttributes($gridField, $record, $columnName)
     {
-        return array('class' => 'col-buttons');
+        return ['class' => 'col-buttons'];
     }
 
     /**
@@ -34,8 +34,8 @@ class CommentsGridFieldAction implements GridField_ColumnProvider, GridField_Act
      */
     public function getColumnMetadata($gridField, $columnName)
     {
-        if ($columnName == 'Actions') {
-            return array('title' => '');
+        if ($columnName === 'Actions') {
+            return ['title' => ''];
         }
     }
 
@@ -44,7 +44,7 @@ class CommentsGridFieldAction implements GridField_ColumnProvider, GridField_Act
      */
     public function getColumnsHandled($gridField)
     {
-        return array('Actions');
+        return ['Actions'];
     }
 
     /**
@@ -64,7 +64,7 @@ class CommentsGridFieldAction implements GridField_ColumnProvider, GridField_Act
                 'CustomAction' . $record->ID . 'Spam',
                 _t(__CLASS__ . '.SPAM', 'Spam'),
                 'spam',
-                array('RecordID' => $record->ID)
+                ['RecordID' => $record->ID]
             )
                 ->addExtraClass('btn btn-secondary grid-field__icon-action')
                 ->Field();
@@ -76,7 +76,7 @@ class CommentsGridFieldAction implements GridField_ColumnProvider, GridField_Act
                 'CustomAction' . $record->ID . 'Approve',
                 _t(__CLASS__ . '.APPROVE', 'Approve'),
                 'approve',
-                array('RecordID' => $record->ID)
+                ['RecordID' => $record->ID]
             )
                 ->addExtraClass('btn btn-secondary grid-field__icon-action')
                 ->Field();
@@ -90,7 +90,7 @@ class CommentsGridFieldAction implements GridField_ColumnProvider, GridField_Act
      */
     public function getActions($gridField)
     {
-        return array('spam', 'approve');
+        return ['spam', 'approve'];
     }
 
     /**
@@ -98,7 +98,8 @@ class CommentsGridFieldAction implements GridField_ColumnProvider, GridField_Act
      */
     public function handleAction(GridField $gridField, $actionName, $arguments, $data)
     {
-        if ($actionName == 'spam') {
+        if ($actionName === 'spam') {
+            /** @var Comment $comment */
             $comment = Comment::get()->byID($arguments['RecordID']);
             $comment->markSpam();
 
@@ -109,7 +110,8 @@ class CommentsGridFieldAction implements GridField_ColumnProvider, GridField_Act
             );
         }
 
-        if ($actionName == 'approve') {
+        if ($actionName === 'approve') {
+            /** @var Comment $comment */
             $comment = Comment::get()->byID($arguments['RecordID']);
             $comment->markApproved();
 

--- a/src/Admin/CommentsGridFieldConfig.php
+++ b/src/Admin/CommentsGridFieldConfig.php
@@ -20,8 +20,9 @@ class CommentsGridFieldConfig extends GridFieldConfig_RecordEditor
         $this->addComponent(new CommentsGridFieldAction());
 
         // Format column
+        /** @var GridFieldDataColumns $columns */
         $columns = $this->getComponentByType(GridFieldDataColumns::class);
-        $columns->setFieldFormatting(array(
+        $columns->setFieldFormatting([
             'ParentTitle' => function ($value, &$item) {
                 return sprintf(
                     '<a href="%s" class="cms-panel-link external-link action" target="_blank">%s</a>',
@@ -29,10 +30,10 @@ class CommentsGridFieldConfig extends GridFieldConfig_RecordEditor
                     $item->obj('ParentTitle')->forTemplate()
                 );
             }
-        ));
+        ]);
 
         // Add bulk option
-        $manager = new BulkManager(null, false);
+        $manager = BulkManager::create(null, false);
 
         $spamAction = SpamHandler::create()->setLabel(_t(__CLASS__ . '.SPAM', 'Spam'));
         $approveAction = ApproveHandler::create()->setLabel(_t(__CLASS__ . '.APPROVE', 'Approve'));

--- a/src/Extensions/CommentsExtension.php
+++ b/src/Extensions/CommentsExtension.php
@@ -157,13 +157,16 @@ class CommentsExtension extends DataExtension
 
         // Check if enabled setting should be cms configurable
         if ($this->owner->getCommentsOption('enabled_cms')) {
-            $options->push(new CheckboxField('ProvideComments', _t('SilverStripe\\Comments\\Model\\Comment.ALLOWCOMMENTS', 'Allow Comments')));
+            $options->push(CheckboxField::create('ProvideComments', _t(
+                'SilverStripe\\Comments\\Model\\Comment.ALLOWCOMMENTS',
+                'Allow Comments'
+            )));
         }
 
         // Check if we should require users to login to comment
         if ($this->owner->getCommentsOption('require_login_cms')) {
             $options->push(
-                new CheckboxField(
+                CheckboxField::create(
                     'CommentsRequireLogin',
                     _t('Comments.COMMENTSREQUIRELOGIN', 'Require login to comment')
                 )
@@ -180,16 +183,23 @@ class CommentsExtension extends DataExtension
 
         // Check if moderation should be enabled via cms configurable
         if ($this->owner->getCommentsOption('require_moderation_cms')) {
-            $moderationField = new DropdownField('ModerationRequired', _t(__CLASS__ . '.COMMENTMODERATION', 'Comment Moderation'), array(
-                'None' => _t(__CLASS__ . '.MODERATIONREQUIRED_NONE', 'No moderation required'),
-                'Required' => _t(__CLASS__ . '.MODERATIONREQUIRED_REQUIRED', 'Moderate all comments'),
-                'NonMembersOnly' => _t(
-                    __CLASS__ . '.MODERATIONREQUIRED_NONMEMBERSONLY',
-                    'Only moderate non-members'
+            $moderationField = DropdownField::create(
+                'ModerationRequired',
+                _t(
+                    __CLASS__ . '.COMMENTMODERATION',
+                    'Comment Moderation'
                 ),
-            ));
+                [
+                    'None' => _t(__CLASS__ . '.MODERATIONREQUIRED_NONE', 'No moderation required'),
+                    'Required' => _t(__CLASS__ . '.MODERATIONREQUIRED_REQUIRED', 'Moderate all comments'),
+                    'NonMembersOnly' => _t(
+                        __CLASS__ . '.MODERATIONREQUIRED_NONMEMBERSONLY',
+                        'Only moderate non-members'
+                    ),
+                ]
+            );
             if ($fields->hasTabSet()) {
-                $fields->addFieldsToTab('Root.Settings', $moderationField);
+                $fields->addFieldToTab('Root.Settings', $moderationField);
             } else {
                 $fields->push($moderationField);
             }

--- a/src/Forms/CommentForm.php
+++ b/src/Forms/CommentForm.php
@@ -17,7 +17,6 @@ use SilverStripe\Forms\ReadonlyField;
 use SilverStripe\Forms\RequiredFields;
 use SilverStripe\Forms\TextareaField;
 use SilverStripe\Forms\TextField;
-use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;
 
 class CommentForm extends Form
@@ -99,7 +98,7 @@ class CommentForm extends Form
             );
         }
 
-        $required = new RequiredFields(
+        $required = RequiredFields::create(
             $controller->config()->required_fields
         );
 
@@ -109,22 +108,22 @@ class CommentForm extends Form
         // if the record exists load the extra required data
         if ($record = $controller->getOwnerRecord()) {
             // Load member data
-            $member = Member::currentUser();
+            $member = Security::getCurrentUser();
             if (($record->CommentsRequireLogin || $record->PostingRequiredPermission) && $member) {
                 $fields = $this->Fields();
 
                 $fields->removeByName('Name');
                 $fields->removeByName('Email');
                 $fields->insertBefore(
-                    new ReadonlyField(
+                    ReadonlyField::create(
                         'NameView',
                         _t('CommentInterface.YOURNAME', 'Your name'),
                         $member->getName()
                     ),
                     'URL'
                 );
-                $fields->push(new HiddenField('Name', '', $member->getName()));
-                $fields->push(new HiddenField('Email', '', $member->Email));
+                $fields->push(HiddenField::create('Name', '', $member->getName()));
+                $fields->push(HiddenField::create('Email', '', $member->Email));
             }
 
             // we do not want to read a new URL when the form has already been submitted
@@ -220,7 +219,7 @@ class CommentForm extends Form
         }
 
         if ($member = Security::getCurrentUser()) {
-            $form->Fields()->push(new HiddenField('AuthorID', 'Author ID', $member->ID));
+            $form->Fields()->push(HiddenField::create('AuthorID', 'Author ID', $member->ID));
         }
 
         // What kind of moderation is required?

--- a/src/Forms/CommentForm.php
+++ b/src/Forms/CommentForm.php
@@ -44,18 +44,27 @@ class CommentForm extends Form
                 // Email
                 EmailField::create(
                     'Email',
-                    _t('SilverStripe\\Comments\\Controllers\\CommentingController.EMAILADDRESS', 'Your email address (will not be published)')
+                    _t(
+                        'SilverStripe\\Comments\\Controllers\\CommentingController.EMAILADDRESS',
+                        'Your email address (will not be published)'
+                    )
                 )
                     ->setCustomValidationMessage($emailRequired)
                     ->setAttribute('data-msg-required', $emailRequired)
                     ->setAttribute('data-msg-email', $emailInvalid)
                     ->setAttribute('data-rule-email', true),
                 // Url
-                TextField::create('URL', _t('SilverStripe\\Comments\\Controllers\\CommentingController.WEBSITEURL', 'Your website URL'))
+                TextField::create('URL', _t(
+                    'SilverStripe\\Comments\\Controllers\\CommentingController.WEBSITEURL',
+                    'Your website URL'
+                ))
                     ->setAttribute('data-msg-url', $urlInvalid)
                     ->setAttribute('data-rule-url', true),
                 // Comment
-                TextareaField::create('Comment', _t('SilverStripe\\Comments\\Controllers\\CommentingController.COMMENTS', 'Comments'))
+                TextareaField::create('Comment', _t(
+                    'SilverStripe\\Comments\\Controllers\\CommentingController.COMMENTS',
+                    'Comments'
+                ))
                     ->setCustomValidationMessage($commentRequired)
                     ->setAttribute('data-msg-required', $commentRequired)
             ),


### PR DESCRIPTION
* Switch to short brackets for arrays
* Optimise imports
* Use Injector to instantiate objects where possible
* Remove redundant phpcs rules (originally copied from framework and not changed to suit the module)
* Remove redundant else statements after a return
* Add PHPDoc type hints where necessary