### PR TITLE
Fix move loading Cookie data to before the logged user check to prevent 'sticky' user data

### DIFF
--- a/src/Forms/CommentForm.php
+++ b/src/Forms/CommentForm.php
@@ -98,6 +98,23 @@ class CommentForm extends Form
 
         parent::__construct($controller, $name, $fields, $actions, $required);
 
+        // load any data from the cookies
+        if ($data = Cookie::get('CommentsForm_UserData')) {
+            $data = Convert::json2array($data);
+
+            $this->loadDataFrom(array(
+                'Name'  => isset($data['Name']) ? $data['Name'] : '',
+                'URL'   => isset($data['URL']) ? $data['URL'] : '',
+                'Email' => isset($data['Email']) ? $data['Email'] : ''
+            ));
+
+            // allow previous value to fill if comment not stored in cookie (i.e. validation error)
+            $prevComment = Cookie::get('CommentsForm_Comment');
+
+            if ($prevComment && $prevComment != '') {
+                $this->loadDataFrom(array('Comment' => $prevComment));
+            }
+        }
 
         // if the record exists load the extra required data
         if ($record = $controller->getOwnerRecord()) {
@@ -131,24 +148,6 @@ class CommentForm extends Form
 
         // Set it so the user gets redirected back down to the form upon form fail
         $this->setRedirectToFormOnValidationError(true);
-
-        // load any data from the cookies
-        if ($data = Cookie::get('CommentsForm_UserData')) {
-            $data = Convert::json2array($data);
-
-            $this->loadDataFrom(array(
-                'Name'  => isset($data['Name']) ? $data['Name'] : '',
-                'URL'   => isset($data['URL']) ? $data['URL'] : '',
-                'Email' => isset($data['Email']) ? $data['Email'] : ''
-            ));
-
-            // allow previous value to fill if comment not stored in cookie (i.e. validation error)
-            $prevComment = Cookie::get('CommentsForm_Comment');
-
-            if ($prevComment && $prevComment != '') {
-                $this->loadDataFrom(array('Comment' => $prevComment));
-            }
-        }
     }
 
     /**


### PR DESCRIPTION
Currently the cookie set user details overrides the logged in user data, meaning that once a logged in user has posted their details remain even if a new user logs in.

Steps to recreate:
 - Set `require_login: true`
 - Log in as User1
 - Post a comment. Comment's user name will be User1's details
 - Log out
 - Log in as User2
 - Post a comment. Comment's user name still be User1's details