### PR TITLE
FIX RSS feed for comments now render correctly

### DIFF
--- a/src/Extensions/CommentsExtension.php
+++ b/src/Extensions/CommentsExtension.php
@@ -441,7 +441,7 @@ class CommentsExtension extends DataExtension
     {
         return Controller::join_links(
             $this->getCommentRSSLink(),
-            str_replace('\\', '-', $this->owner->baseClass()),
+            str_replace('\\', '-', get_class($this->owner)),
             $this->owner->ID
         );
     }


### PR DESCRIPTION
The comment DataList filter applies ParentClass = $className - when this is the base class, it fails to recognise comments for a BlogPost. This change uses the late class name instead.

Fixes #270