### PR TITLE
FIX show name of members in summary tables

### DIFF
--- a/src/Model/Comment.php
+++ b/src/Model/Comment.php
@@ -125,8 +125,8 @@ class Comment extends DataObject
      * {@inheritDoc}
      */
     private static $summary_fields = array(
-        'Name' => 'Submitted By',
-        'Email' => 'Email',
+        'getAuthorName' => 'Submitted By',
+        'getAuthorEmail' => 'Email',
         'Comment.LimitWordCount' => 'Comment',
         'Created' => 'Date Posted',
         'Parent.Title' => 'Post',
@@ -447,6 +447,20 @@ class Comment extends DataObject
             return $this->Name;
         } elseif ($author = $this->Author()) {
             return $author->getName();
+        }
+    }
+
+    /**
+     * Return the comment authors email address
+     *
+     * @return string
+     */
+    public function getAuthorEmail()
+    {
+        if ($this->Email) {
+            return $this->Email;
+        } elseif ($author = $this->Author()) {
+            return $author->Email;
         }
     }
 


### PR DESCRIPTION
Anonymous comments (posted by the public at large) must have a name
and an email address associated with them. On the other hand, a logged
in user will have the `Member` record details used for this information,
via the Author relationship.

However the summary fields do not allow for this, and only reference
Name and Email on the Comment model directly, so any comment posted by a
logged in member has no data for name and email displayed in the various
GridFields in the CMS for administering comments (either per page, or in
the global ModelAdmin).

To recitfy this we can change the summary fields to use getter methods
that will return the Comment model info, or fall back to the Author
associated Member record if Name and Email are unset on the Comment.

Resolves #260 

![image](https://user-images.githubusercontent.com/778003/51002285-b0163080-1597-11e9-98a6-f610bc450c64.png)

![image](https://user-images.githubusercontent.com/778003/51002346-dfc53880-1597-11e9-8c9e-413392ee0526.png)
