### PR TITLE
FIX Correcting inconsistent capitalisation of label and cleaning up tests

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -74,7 +74,7 @@ en:
     EMAIL: Email
     ISSPAM: 'Spam?'
     MODERATED: 'Moderated?'
-    NAME: 'Author Name'
+    NAME: 'Author name'
     'ON': 'on'
     OPTIONS: Options
     OPTION_DESCRIPTION: 'Unmoderated and spam comments will not be displayed until approved'

--- a/src/Model/Comment.php
+++ b/src/Model/Comment.php
@@ -219,7 +219,7 @@ class Comment extends DataObject
     {
         $labels = parent::fieldLabels($includerelations);
 
-        $labels['Name'] = _t(__CLASS__ . '.NAME', 'Author Name');
+        $labels['Name'] = _t(__CLASS__ . '.NAME', 'Author name');
         $labels['Comment'] = _t(__CLASS__ . '.COMMENT', 'Comment');
         $labels['Email'] = _t(__CLASS__ . '.EMAIL', 'Email');
         $labels['URL'] = _t(__CLASS__ . '.URL', 'URL');

--- a/tests/CommentsTest.php
+++ b/tests/CommentsTest.php
@@ -605,34 +605,8 @@ class CommentsTest extends FunctionalTest
      */
     public function testFieldLabels()
     {
-        $locale = i18n::get_locale();
-        i18n::set_locale('fr');
-
         /** @var Comment $comment */
         $comment = $this->objFromFixture(Comment::class, 'firstComA');
-
-        $labels = $comment->FieldLabels();
-        $expected = array(
-            'Name' => 'Nom de l\'Auteur',
-            'Comment' => 'Commentaire',
-            'Email' => 'Email',
-            'URL' => 'URL',
-            'Moderated' => 'Modéré?',
-            'IsSpam' => 'Spam?',
-            'AllowHtml' => 'Allow Html',
-            'SecretToken' => 'Secret Token',
-            'Depth' => 'Depth',
-            'Author' => 'Author Member',
-            'ParentComment' => 'Parent Comment',
-            'ChildComments' => 'Child Comments',
-            'ParentTitle' => 'Parent',
-            'Created' => 'Date de publication',
-            'Parent' => 'Parent'
-        );
-        i18n::set_locale($locale);
-        foreach ($expected as $key => $value) {
-            $this->assertEquals($value, $labels[$key]);
-        }
 
         $labels = $comment->FieldLabels();
         $expected = array(
@@ -640,17 +614,10 @@ class CommentsTest extends FunctionalTest
             'Comment' => 'Comment',
             'Email' => 'Email',
             'URL' => 'URL',
-            'Moderated' => 'Moderated?',
             'IsSpam' => 'Spam?',
-            'AllowHtml' => 'Allow Html',
-            'SecretToken' => 'Secret Token',
-            'Depth' => 'Depth',
-            'Author' => 'Author Member',
-            'ParentComment' => 'Parent Comment',
-            'ChildComments' => 'Child Comments',
+            'Moderated' => 'Moderated?',
             'ParentTitle' => 'Parent',
             'Created' => 'Date posted',
-            'Parent' => 'Parent'
         );
         foreach ($expected as $key => $value) {
             $this->assertEquals($value, $labels[$key]);

--- a/tests/CommentsTest.php
+++ b/tests/CommentsTest.php
@@ -610,7 +610,7 @@ class CommentsTest extends FunctionalTest
 
         $labels = $comment->FieldLabels();
         $expected = array(
-            'Name' => 'Author Name',
+            'Name' => 'Author name',
             'Comment' => 'Comment',
             'Email' => 'Email',
             'URL' => 'URL',


### PR DESCRIPTION
This fixes the builds that run against the latest framework version as there was a recent change (https://github.com/silverstripe/silverstripe-framework/pull/8698) that changes how labels are generated to have better casing. It does this by only testing the labels that are specifically specified.

Additionally this removes the unnecessary tests of the `i18n` system.