### PR TITLE
Validate protocol-less URLs

### DIFF
--- a/javascript/CommentsInterface.js
+++ b/javascript/CommentsInterface.js
@@ -2,7 +2,16 @@
  * @package comments
  */
 (function($) {
+    // The above closure encapsulates the $ variable away from the global scope
+    // and the one below is the `$(document).ready(...)` shorthand.
 	$(function() {
+        // Override the default URL validator in order to extend it to allow protocol-less URLs
+		$.validator.methods.url = function( value, element ) {
+            // This line is copied directly from the jQuery.validation source (version 1.19.0)
+            // the only change is a single question mark added here ---------v
+			return this.optional( element ) || /^(?:(?:(?:https?|ftp):)?\/\/)?(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})).?)(?::\d{2,5})?(?:[/?#]\S*)?$/i.test( value );
+		}
+
 		/**
 		 * Enable form validation
 		 */


### PR DESCRIPTION
Closes #272 
~~Depends on #275~~ _rebased the critical commit onto `3.1`_

Update JavaScript validation of the URL input to allow for protocol-less but otherwise valid URLs.

e.g. `somesite.test` as opposed to requiring `http://somesite.test`