### PR TITLE
NEW relocate spam and approve admin actions

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,69 +1,15 @@
 inherit: true
 
+build:
+  nodes:
+    analysis:
+      tests:
+        override: [php-scrutinizer-run]
+
 checks:
   php:
-    verify_property_names: true
-    verify_argument_usable_as_reference: true
-    verify_access_scope_valid: true
-    useless_calls: true
-    use_statement_alias_conflict: true
-    variable_existence: true
-    unused_variables: true
-    unused_properties: true
-    unused_parameters: true
-    unused_methods: true
-    unreachable_code: true
-    too_many_arguments: true
-    sql_injection_vulnerabilities: true
-    simplify_boolean_return: true
-    side_effects_or_types: true
-    security_vulnerabilities: true
-    return_doc_comments: true
-    return_doc_comment_if_not_inferrable: true
-    require_scope_for_properties: true
-    require_scope_for_methods: true
-    require_php_tag_first: true
-    psr2_switch_declaration: true
-    psr2_class_declaration: true
-    property_assignments: true
-    prefer_while_loop_over_for_loop: true
-    precedence_mistakes: true
-    precedence_in_conditions: true
-    phpunit_assertions: true
-    php5_style_constructor: true
-    parse_doc_comments: true
-    parameter_non_unique: true
-    parameter_doc_comments: true
-    param_doc_comment_if_not_inferrable: true
-    optional_parameters_at_the_end: true
-    one_class_per_file: true
-    no_unnecessary_if: true
-    no_trailing_whitespace: true
-    no_property_on_interface: true
-    no_non_implemented_abstract_methods: true
-    no_error_suppression: true
-    no_duplicate_arguments: true
-    no_commented_out_code: true
-    newline_at_end_of_file: true
-    missing_arguments: true
-    method_calls_on_non_object: true
-    instanceof_class_exists: true
-    foreach_traversable: true
-    fix_line_ending: true
-    fix_doc_comments: true
-    duplication: true
-    deprecated_code_usage: true
-    deadlock_detection_in_loops: true
     code_rating: true
-    closure_use_not_conflicting: true
-    catch_class_exists: true
-    blank_line_after_namespace_declaration: false
-    avoid_multiple_statements_on_same_line: true
-    avoid_duplicate_types: true
-    avoid_conflicting_incrementers: true
-    avoid_closing_tag: true
-    assignment_of_null_return: true
-    argument_type_checks: true
+    duplication: true
 
 filter:
   paths: [src/*, tests/*]

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,14 @@ dist: trusty
 matrix:
   include:
     - php: 5.6
-      env: DB=MYSQL INSTALLER_VERSION=4.0.x-dev PHPCS_TEST=1 PHPUNIT_TEST=1
+      env: DB=MYSQL INSTALLER_VERSION=4.2.x-dev PHPCS_TEST=1 PHPUNIT_TEST=1
     - php: 7.0
-      env: DB=PGSQL INSTALLER_VERSION=4.1.x-dev PHPUNIT_TEST=1
+      env: DB=PGSQL INSTALLER_VERSION=4.2.x-dev PHPUNIT_TEST=1
     - php: 7.1
-      env: DB=MYSQL INSTALLER_VERSION=4.2.x-dev PHPUNIT_COVERAGE_TEST=1
+      env: DB=MYSQL INSTALLER_VERSION=4.3.x-dev PHPUNIT_COVERAGE_TEST=1
     - php: 7.2
+      env: DB=MYSQL INSTALLER_VERSION=4.3.x-dev PHPUNIT_TEST=1
+    - php: 7.3
       env: DB=MYSQL INSTALLER_VERSION=4.x-dev PHPUNIT_TEST=1
 
 before_script:
@@ -17,7 +19,7 @@ before_script:
   - phpenv config-rm xdebug.ini
   - composer validate
   - composer require silverstripe/installer:"$INSTALLER_VERSION" ezyang/htmlpurifier:* --no-update
-  - if [[ $DB == PGSQL ]]; then composer require --no-update silverstripe/postgresql:2.0.x-dev; fi
+  - if [[ $DB == PGSQL ]]; then composer require --no-update silverstripe/postgresql:2.x-dev; fi
   - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_script:
   - phpenv config-rm xdebug.ini
   - composer validate
   - composer require silverstripe/installer:"$INSTALLER_VERSION" ezyang/htmlpurifier:* --no-update
-  - if [[ $DB == PGSQL ]]; then composer require --no-update silverstripe/postgresql:2.x-dev; fi
+  - if [[ $DB == PGSQL ]]; then composer require --no-update silverstripe/postgresql:2.2.x-dev; fi
   - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "silverstripe/framework": "^4.0",
+        "silverstripe/framework": "^4.2",
         "colymba/gridfield-bulk-editing-tools": "^3.0"
     },
     "suggest": {

--- a/src/Admin/CommentsGridFieldAction.php
+++ b/src/Admin/CommentsGridFieldAction.php
@@ -9,6 +9,9 @@ use SilverStripe\Forms\GridField\GridField_ActionProvider;
 use SilverStripe\Forms\GridField\GridField_ColumnProvider;
 use SilverStripe\Forms\GridField\GridField_FormAction;
 
+/**
+ * @deprecated 3.2.0 {@see CommentsGridFieldApproveAction} and {@see CommentsGridFieldSpamAction} instead
+ */
 class CommentsGridFieldAction implements GridField_ColumnProvider, GridField_ActionProvider
 {
     /**

--- a/src/Admin/CommentsGridFieldApproveAction.php
+++ b/src/Admin/CommentsGridFieldApproveAction.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace SilverStripe\Comments\Admin;
+
+use SilverStripe\Comments\Model\Comment;
+use SilverStripe\Control\Controller;
+use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridField_ActionMenuItem;
+use SilverStripe\Forms\GridField\GridField_ActionProvider;
+use SilverStripe\Forms\GridField\GridField_ColumnProvider;
+use SilverStripe\Forms\GridField\GridField_FormAction;
+
+class CommentsGridFieldApproveAction implements
+    GridField_ColumnProvider,
+    GridField_ActionProvider,
+    GridField_ActionMenuItem
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function augmentColumns($gridField, &$columns)
+    {
+        if (!in_array('Actions', $columns)) {
+            $columns[] = 'Actions';
+        }
+    }
+
+    public function getTitle($gridField, $record, $columnName)
+    {
+        return _t(__CLASS__ . '.APPROVE', 'Approve');
+    }
+
+    public function getExtraData($gridField, $record, $columnName)
+    {
+
+        $field = $this->getApproveAction($gridField, $record, $columnName);
+
+        if ($field) {
+            return $field->getAttributes();
+        }
+
+        return null;
+    }
+    public function getGroup($gridField, $record, $columnName)
+    {
+        $field = $this->getApproveAction($gridField, $record, $columnName);
+
+        return $field ? GridField_ActionMenuItem::DEFAULT_GROUP: null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getColumnAttributes($gridField, $record, $columnName)
+    {
+        return ['class' => 'col-buttons grid-field__col-compact'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getColumnMetadata($gridField, $columnName)
+    {
+        if ($columnName === 'Actions') {
+            return ['title' => ''];
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getColumnsHandled($gridField)
+    {
+        return ['Actions'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getColumnContent($gridField, $record, $columnName)
+    {
+        if (!$record->canEdit()) {
+            return;
+        }
+
+        $field = $this->getApproveAction($gridField, $record, $columnName);
+
+        return $field ? $field->Field() : null;
+    }
+
+    /**
+     * Returns the FormAction object, used by other methods to get properties
+     *
+     * @return GridField_FormAction
+     */
+    public function getApproveAction($gridField, $record, $columnName)
+    {
+        $field = GridField_FormAction::create(
+            $gridField,
+            'CustomAction' . $record->ID . 'Approve',
+            _t(__CLASS__ . '.APPROVE', 'Approve'),
+            'approve',
+            ['RecordID' => $record->ID]
+        )
+            ->addExtraClass(implode(' ', [
+                'btn',
+                'btn-secondary',
+                'grid-field__icon-action',
+                'action-menu--handled',
+                'font-icon-check-mark',
+            ]))
+            ->setAttribute('classNames', 'font-icon-check-mark');
+
+        return ($record->IsSpam || !$record->Moderated) ? $field : null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getActions($gridField)
+    {
+        return ['approve'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handleAction(GridField $gridField, $actionName, $arguments, $data)
+    {
+        /** @var Comment $comment */
+        $comment = Comment::get()->byID($arguments['RecordID']);
+        $comment->markApproved();
+
+        // output a success message to the user
+        Controller::curr()->getResponse()->setStatusCode(
+            200,
+            _t(__CLASS__ . '.COMMENTAPPROVED', 'Comment approved.')
+        );
+    }
+}

--- a/src/Admin/CommentsGridFieldApproveAction.php
+++ b/src/Admin/CommentsGridFieldApproveAction.php
@@ -91,7 +91,7 @@ class CommentsGridFieldApproveAction implements
     /**
      * Returns the FormAction object, used by other methods to get properties
      *
-     * @return GridField_FormAction
+     * @return GridField_FormAction|null
      */
     public function getApproveAction($gridField, $record, $columnName)
     {

--- a/src/Admin/CommentsGridFieldConfig.php
+++ b/src/Admin/CommentsGridFieldConfig.php
@@ -6,6 +6,7 @@ use Colymba\BulkManager\BulkManager;
 use SilverStripe\Comments\Admin\CommentsGridFieldBulkAction\ApproveHandler;
 use SilverStripe\Comments\Admin\CommentsGridFieldBulkAction\SpamHandler;
 use SilverStripe\Core\Convert;
+use SilverStripe\Forms\GridField\GridField_ActionMenu;
 use SilverStripe\Forms\GridField\GridFieldConfig_RecordEditor;
 use SilverStripe\Forms\GridField\GridFieldDataColumns;
 
@@ -17,7 +18,10 @@ class CommentsGridFieldConfig extends GridFieldConfig_RecordEditor
 
         // $this->addComponent(new GridFieldExportButton());
 
-        $this->addComponent(new CommentsGridFieldAction());
+        $this->addComponents([
+            new CommentsGridFieldSpamAction(),
+            new CommentsGridFieldApproveAction(),
+        ]);
 
         // Format column
         /** @var GridFieldDataColumns $columns */

--- a/src/Admin/CommentsGridFieldSpamAction.php
+++ b/src/Admin/CommentsGridFieldSpamAction.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace SilverStripe\Comments\Admin;
+
+use SilverStripe\Comments\Model\Comment;
+use SilverStripe\Control\Controller;
+use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridField_ActionMenuItem;
+use SilverStripe\Forms\GridField\GridField_ActionProvider;
+use SilverStripe\Forms\GridField\GridField_ColumnProvider;
+use SilverStripe\Forms\GridField\GridField_FormAction;
+
+class CommentsGridFieldSpamAction implements
+    GridField_ColumnProvider,
+    GridField_ActionProvider,
+    GridField_ActionMenuItem
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function augmentColumns($gridField, &$columns)
+    {
+        if (!in_array('Actions', $columns)) {
+            $columns[] = 'Actions';
+        }
+    }
+
+    public function getTitle($gridField, $record, $columnName)
+    {
+        return _t(__CLASS__ . '.SPAM', 'Spam');
+    }
+
+    public function getExtraData($gridField, $record, $columnName)
+    {
+
+        $field = $this->getSpamAction($gridField, $record, $columnName);
+
+        if ($field) {
+            return $field->getAttributes();
+        }
+
+        return null;
+    }
+
+    public function getGroup($gridField, $record, $columnName)
+    {
+        $field = $this->getSpamAction($gridField, $record, $columnName);
+
+        return $field ? GridField_ActionMenuItem::DEFAULT_GROUP: null;
+    }
+
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getColumnAttributes($gridField, $record, $columnName)
+    {
+        return ['class' => 'col-buttons grid-field__col-compact'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getColumnMetadata($gridField, $columnName)
+    {
+        if ($columnName === 'Actions') {
+            return ['title' => ''];
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getColumnsHandled($gridField)
+    {
+        return ['Actions'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getColumnContent($gridField, $record, $columnName)
+    {
+        if (!$record->canEdit()) {
+            return;
+        }
+
+        $field = $this->getSpamAction($gridField, $record, $columnName);
+
+        return $field ? $field->Field() : null;
+    }
+
+    /**
+     * Returns the FormAction object, used by other methods to get properties
+     *
+     * @return GridField_FormAction
+     */
+    public function getSpamAction($gridField, $record, $columnName)
+    {
+        $field = GridField_FormAction::create(
+            $gridField,
+            'CustomAction' . $record->ID . 'Spam',
+            _t(__CLASS__ . '.SPAM', 'Spam'),
+            'spam',
+            ['RecordID' => $record->ID]
+        )
+            ->addExtraClass(implode(' ', [
+                'btn',
+                'btn-secondary',
+                'grid-field__icon-action',
+                'action-menu--handled',
+                'font-icon-cross-mark',
+            ]))
+            ->setAttribute('classNames', 'font-icon-cross-mark');
+        return (!$record->IsSpam || !$record->Moderated) ? $field : null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getActions($gridField)
+    {
+        return ['spam'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handleAction(GridField $gridField, $actionName, $arguments, $data)
+    {
+        /** @var Comment $comment */
+        $comment = Comment::get()->byID($arguments['RecordID']);
+        $comment->markSpam();
+
+        // output a success message to the user
+        Controller::curr()->getResponse()->setStatusCode(
+            200,
+            _t(__CLASS__ . '.COMMENTMARKEDSPAM', 'Comment marked as spam.')
+        );
+    }
+}

--- a/src/Admin/CommentsGridFieldSpamAction.php
+++ b/src/Admin/CommentsGridFieldSpamAction.php
@@ -93,7 +93,7 @@ class CommentsGridFieldSpamAction implements
     /**
      * Returns the FormAction object, used by other methods to get properties
      *
-     * @return GridField_FormAction
+     * @return GridField_FormAction|null
      */
     public function getSpamAction($gridField, $record, $columnName)
     {


### PR DESCRIPTION
Previous versions had individual spam and approve buttons for a comment
in the admin area on the GridField row. However with the upgrade to
SilverStripe 4, and particularly 4.3, these were having layout issues
with the new GridField Action Menu component that groups actions
together.

The solution here is to put them into aforementioned gridfield action
menu component, with the other actions for that row. However this means
a public API change, as this requires two separate grid field
components (one each for the two comment actions) - previously these
were a single component that output two buttons instead of one each.
This also reduces coupling, which is nice :)

Closes #234 

![image](https://user-images.githubusercontent.com/778003/51722213-85f56000-20b9-11e9-9666-2d1eb693f7a3.png)

![image](https://user-images.githubusercontent.com/778003/51722235-a1606b00-20b9-11e9-8e91-a47fef859a42.png)
