### PR TITLE
Adjust the output of CommentHandler to use HTTPBulkToolsResponse

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "silverstripe/framework": "^4.2",
-        "colymba/gridfield-bulk-editing-tools": "^3.0"
+        "colymba/gridfield-bulk-editing-tools": "^3.0.0-beta4"
     },
     "suggest": {
         "ezyang/htmlpurifier": "Standards compliant HTML filter written in PHP",

--- a/src/Admin/CommentsGridFieldBulkAction/CommentHandler.php
+++ b/src/Admin/CommentsGridFieldBulkAction/CommentHandler.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\Comments\Admin\CommentsGridFieldBulkAction;
 
 use Colymba\BulkManager\BulkAction\Handler;
+use Colymba\BulkTools\HTTPBulkToolsResponse;
 use SilverStripe\Comments\Model\Comment;
 use SilverStripe\Core\Convert;
 use SilverStripe\Control\HTTPRequest;
@@ -22,17 +23,19 @@ abstract class CommentHandler extends Handler
     {
         $ids = [];
 
+        $response = new HTTPBulkToolsResponse(
+            true,
+            $this->gridField,
+            200
+        );
+
         foreach ($this->getRecords() as $comment) {
             array_push($ids, $comment->ID);
             $this->updateComment($comment);
+            $response->addSuccessRecord($comment);
         }
 
-        $response = new HTTPResponse(json_encode([
-            'done' => true,
-            'records' => $ids,
-        ]));
-
-        $response->addHeader('Content-Type', 'application/json');
+        $response->setMessage('Changes applied');
 
         return $response;
     }

--- a/src/Admin/CommentsGridFieldBulkAction/CommentHandler.php
+++ b/src/Admin/CommentsGridFieldBulkAction/CommentHandler.php
@@ -35,7 +35,7 @@ abstract class CommentHandler extends Handler
             $response->addSuccessRecord($comment);
         }
 
-        $response->setMessage('Changes applied');
+        $response->setMessage(_t(__CLASS__ . '.CHANGES_APPLIED', 'Changes applied'));
 
         return $response;
     }


### PR DESCRIPTION
GridFieldBulkEditingTools has introduced a common output schema in the form of HTTPBulkToolsResponse. This PR adopts that API for bulk operations, which fixes a console error and results in the GridField reloading (which is a fairly significant UX win - any comments that have been removed from the GridField as a result of the operation will actually disappear).

Fixes #241.