### PR TITLE
comments extension filters on Parent Class

### DIFF
--- a/src/Extensions/CommentsExtension.php
+++ b/src/Extensions/CommentsExtension.php
@@ -254,7 +254,10 @@ class CommentsExtension extends DataExtension
     {
         $order = $this->owner->getCommentsOption('order_comments_by');
         $comments = Comment::get()
-            ->filter('ParentID', $this->owner->ID)
+            ->filter([
+                'ParentID' => $this->owner->ID,
+                'ParentClass' => $this->owner->ClassName,
+            ])
             ->sort($order);
         $this->owner->extend('updateAllComments', $comments);
         return $comments;


### PR DESCRIPTION
This allows both pages and DataObjects to have comments without the ParentID clashing and showing comments on a page where the ParentID is the Same as a DataObjects or even two DataObjects having the sameID