### PR TITLE
Restore empty comments.css file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "expose": [
             "client/dist",
             "client/lang",
+            "css",
             "thirdparty"
         ]
     },

--- a/css/comments.css
+++ b/css/comments.css
@@ -1,0 +1,1 @@
+/** Deprecated. Remove in 4.0 release. */


### PR DESCRIPTION
Following https://github.com/silverstripe/silverstripe-comments/pull/297, if you've overridden `templates/CommentsInterface.ss`, you'll get an error.

This file just includes a blank CSS file to avoid errors in those set up.

# Parent issue
* https://github.com/silverstripeltd/product-issues/issues/48