### PR TITLE
Add a key when enabling the CommentsExtension in the config.

### DIFF
--- a/_config/comments.yml
+++ b/_config/comments.yml
@@ -6,6 +6,6 @@ only:
 ---
 SilverStripe\CMS\Model\SiteTree:
   extensions:
-    - SilverStripe\Comments\Extensions\CommentsExtension
+    comments: SilverStripe\Comments\Extensions\CommentsExtension
   comments:
     enabled_cms: true


### PR DESCRIPTION
As outlined in https://github.com/silverstripe/silverstripe-cms/issues/2146, this would allow modules to unset the CommentsExtension like this:
```
SilverStripe\CMS\Model\SiteTree:
  extensions:
    comments: null
MyCommentsPage
  extensions:
    comments: SilverStripe\Comments\Extensions\CommentsExtension
```
The key issue is that enabling the comments extension for all of SiteTree might not always be the best choice, as sometimes only specific subpages will need comments. This PR allows users to select which object they'd like to add the CommentsExtension rather than applying it to all pages at once, should they want to do so.