### PR TITLE
FIX Don't use deprecated API

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -1,3 +1,0 @@
-<?php
-
-\SilverStripe\Dev\Deprecation::notification_version('3.0', 'comments');


### PR DESCRIPTION
`Deprecation::notification_version()` is deprecated - we shouldn't be calling it.
There's a `_config` directory so we don't need to keep an empty `_config.php` file.

## Issue
- https://github.com/silverstripeltd/product-issues/issues/692