### PR TITLE
DEP Bump minimum version of framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "silverstripe/framework": "^4.10",
+        "silverstripe/framework": "^4.13",
         "colymba/gridfield-bulk-editing-tools": "^3.0.0-beta4"
     },
     "suggest": {


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/284

Failing on Deprecation::withNoReplacement() on --prefer-lowest build

https://github.com/silverstripe/silverstripe-comments/actions/runs/9851668103